### PR TITLE
Move shared config into environment files on the agent

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+max_line_length = 120

--- a/chroma-agent.service
+++ b/chroma-agent.service
@@ -8,6 +8,7 @@ PartOf=iml-storage-server.target
 [Service]
 Type=simple
 ExecStart=/usr/bin/chroma-agent-daemon
+EnvironmentFile=/etc/iml/manager-url.conf
 Restart=on-failure
 StandardOutput=journal
 StandardError=journal

--- a/chroma_agent/action_plugins/agent_updates.py
+++ b/chroma_agent/action_plugins/agent_updates.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 Intel Corporation. All rights reserved.
+# Copyright (c) 2018 Intel Corporation. All rights reserved.
 # Use of this source code is governed by a MIT-style
 # license that can be found in the LICENSE file.
 
@@ -13,6 +13,7 @@ from chroma_agent.device_plugins.action_runner import CallbackAfterResponse
 from chroma_agent.device_plugins import lustre
 from chroma_agent.log import daemon_log
 from chroma_agent import config
+from chroma_agent.conf import ENV_PATH
 from chroma_agent.crypto import Crypto
 from chroma_agent.lib.yum_utils import yum_util, yum_check_update
 from iml_common.lib.agent_rpc import agent_result, agent_error, agent_result_ok
@@ -21,7 +22,7 @@ REPO_PATH = '/etc/yum.repos.d'
 
 
 def configure_repo(filename, file_contents):
-    crypto = Crypto(config.path)
+    crypto = Crypto(ENV_PATH)
     full_filename = os.path.join(REPO_PATH, filename)
     temp_full_filename = full_filename + '.tmp'
 

--- a/chroma_agent/agent_daemon.py
+++ b/chroma_agent/agent_daemon.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2017 Intel Corporation. All rights reserved.
+# Copyright (c) 2018 Intel Corporation. All rights reserved.
 # Use of this source code is governed by a MIT-style
 # license that can be found in the LICENSE file.
 
@@ -12,6 +12,7 @@ import signal
 import socket
 
 from chroma_agent import config
+from chroma_agent.conf import ENV_PATH
 from chroma_agent.crypto import Crypto
 from chroma_agent.plugin_manager import ActionPluginManager, DevicePluginManager
 from chroma_agent.agent_client import AgentClient
@@ -62,8 +63,8 @@ def main():
     try:
         daemon_log.info("Entering main loop")
         try:
-            conf = config.get('settings', 'server')
-        except (KeyError, TypeError) as e:
+            url = os.environ["IML_MANAGER_URL"] + 'agent/message/'
+        except KeyError as e:
             daemon_log.error(
                 "No configuration found (must be registered before running the agent service), "
                 "details: %s" % e)
@@ -79,10 +80,9 @@ def main():
             import chroma_agent.plugin_manager
             chroma_agent.plugin_manager.EXCLUDED_PLUGINS += ['corosync']
 
-        agent_client = AgentClient(conf['url'] + "message/",
-                                   ActionPluginManager(),
+        agent_client = AgentClient(url, ActionPluginManager(),
                                    DevicePluginManager(), ServerProperties(),
-                                   Crypto(config.path))
+                                   Crypto(ENV_PATH))
 
         def teardown_callback(*args, **kwargs):
             agent_client.stop()

--- a/chroma_agent/conf.py
+++ b/chroma_agent/conf.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2018 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a MIT-style
+# license that can be found in the LICENSE file.
+
+import os
+
+ENV_PATH = '/etc/iml'
+
+
+def set_server_url(url):
+    if not os.path.exists(ENV_PATH):
+        os.makedirs(ENV_PATH)
+
+    with open('{}/manager-url.conf'.format(ENV_PATH), 'w+') as f:
+        f.write("IML_MANAGER_URL={}\n".format(url))
+
+
+def remove_server_url():
+    os.unlink('{}/manager-url.conf'.format(ENV_PATH))

--- a/chroma_agent/lib/corosync.py
+++ b/chroma_agent/lib/corosync.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a MIT-style
 # license that can be found in the LICENSE file.
 
-
+import os
 import time
 import re
 import socket
@@ -24,7 +24,8 @@ env = Environment(loader=PackageLoader('chroma_agent', 'templates'))
 
 firewall_control = FirewallControl.create(logger=console_log)
 
-talker_thread = None                    # Used to make noise on ring1 to enable corosync detection.
+# Used to make noise on ring1 to enable corosync detection.
+talker_thread = None
 
 
 class RingDetectionError(Exception):
@@ -57,7 +58,7 @@ def generate_ring1_network(ring0):
 def get_ring0():
     # ring0 will always be on the interface used for agent->manager comms
     from urlparse import urlparse
-    server_url = config.get('settings', 'server')['url']
+    server_url = os.environ["IML_MANAGER_URL"] + 'agent/'
     manager_address = socket.gethostbyname(urlparse(server_url).hostname)
     out = AgentShell.try_run(['/sbin/ip', 'route', 'get', manager_address])
     match = re.search(r'dev\s+([^\s]+)', out)

--- a/tests/actions_plugins/test_agent_updates.py
+++ b/tests/actions_plugins/test_agent_updates.py
@@ -35,9 +35,9 @@ baseurl=http://www.test.com/test.repo
 enabled=1
 gpgcheck=0
 sslverify = 1
-sslcacert = /var/lib/chroma/authority.crt
-sslclientkey = /var/lib/chroma/private.pem
-sslclientcert = /var/lib/chroma/self.crt
+sslcacert = /etc/iml/authority.crt
+sslclientkey = /etc/iml/private.pem
+sslclientcert = /etc/iml/self.crt
 """
         provided_content = """
 [Intel-Lustre-Manager]

--- a/tests/data/device_plugins/lustre/Intel-Lustre-Agent.repo
+++ b/tests/data/device_plugins/lustre/Intel-Lustre-Agent.repo
@@ -4,9 +4,9 @@ baseurl=https://cgearing-mac01.local:8000/repo//lustre
 enabled=0
 gpgcheck=0
 sslverify = 1
-sslcacert = /var/lib/chroma/authority.crt
-sslclientkey = /var/lib/chroma/private.pem
-sslclientcert = /var/lib/chroma/self.crt
+sslcacert = /etc/iml/authority.crt
+sslclientkey = /etc/iml/private.pem
+sslclientcert = /etc/iml/self.crt
 proxy=_none_
 
 [lustre-client]
@@ -15,9 +15,9 @@ baseurl=https://cgearing-mac01.local:8000/repo//lustre-client
 enabled=0
 gpgcheck=0
 sslverify = 1
-sslcacert = /var/lib/chroma/authority.crt
-sslclientkey = /var/lib/chroma/private.pem
-sslclientcert = /var/lib/chroma/self.crt
+sslcacert = /etc/iml/authority.crt
+sslclientkey = /etc/iml/private.pem
+sslclientcert = /etc/iml/self.crt
 proxy=_none_
 
 [e2fsprogs]
@@ -26,9 +26,9 @@ baseurl=https://cgearing-mac01.local:8000/repo//e2fsprogs
 enabled=0
 gpgcheck=0
 sslverify = 1
-sslcacert = /var/lib/chroma/authority.crt
-sslclientkey = /var/lib/chroma/private.pem
-sslclientcert = /var/lib/chroma/self.crt
+sslcacert = /etc/iml/authority.crt
+sslclientkey = /etc/iml/private.pem
+sslclientcert = /etc/iml/self.crt
 proxy=_none_
 
 [robinhood]
@@ -37,7 +37,7 @@ baseurl=https://cgearing-mac01.local:8000/repo//robinhood
 enabled=0
 gpgcheck=0
 sslverify = 1
-sslcacert = /var/lib/chroma/authority.crt
-sslclientkey = /var/lib/chroma/private.pem
-sslclientcert = /var/lib/chroma/self.crt
+sslcacert = /etc/iml/authority.crt
+sslclientkey = /etc/iml/private.pem
+sslclientcert = /etc/iml/self.crt
 proxy=_none_


### PR DESCRIPTION
There is some config that is generally useful for many services.
Namely, the manager url and certs to communicate over https.

Move these into environment files so they can be easily accessed by
systemd services.

Signed-off-by: Joe Grund <joe.grund@intel.com>
