### PR TITLE
lustre-audit mount detection broken for raidZ pools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ rpm_deps
 chroma_agent.egg-info/
 _topdir/
 tags
+settings.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,6 @@ addons:
 jobs:
   include:
   - stage: test
-    env: Type='virus scan'
-    script:
-    - ./include/travis/virus-scan.sh
-  - stage: test
     env: Type='module test'
     script:
     - nosetests
@@ -21,8 +17,14 @@ jobs:
     env: Type='mock build test'
     script:
     - ./include/travis/run_in_centos7_docker.sh include/travis/mock_build_test.sh
+  - stage: cd
+    git:
+      depth: 999999
+    env: Type='Continuous Deployment'
+    script:
+      - include/travis/copr-deploy.sh prepare
+      - ./travis_wait "./include/travis/run_in_centos7_docker.sh include/travis/copr-deploy.sh build_srpm"
   - stage: deploy-pypi
-    if: branch =~ ^v\d+\.\d+\.\d+$
     env: Type='PyPi deploy'
     script: skip
     deploy:
@@ -35,7 +37,6 @@ jobs:
         distributions: sdist bdist_wheel
     skip_upload_docs: true
   - stage: deploy-copr
-    if: branch =~ ^v\d+\.\d+\.\d+$
     env: Type='Copr deploy'
     script: skip
     before_deploy:
@@ -46,3 +47,11 @@ jobs:
       script: ./travis_wait "./include/travis/run_in_centos7_docker.sh include/travis/copr-deploy.sh build"
       on:
         all_branches: true
+stages:
+  - test
+  - name: cd
+    if: branch = master AND type = push AND fork = false
+  - name: deploy-pypi
+    if: branch =~ ^v\d+\.\d+\.\d+$
+  - name: deploy-copr
+    if: branch =~ ^v\d+\.\d+\.\d+$

--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 The Manager for Lustre Agent
 
-[![Build Status](https://travis-ci.org/intel-hpdd/iml-agent.svg?branch=master)](https://travis-ci.org/intel-hpdd/iml-agent)
+[![Build Status](https://travis-ci.org/whamcloud/iml-agent.svg?branch=master)](https://travis-ci.org/whamcloud/iml-agent)
 
 [![Build Status](https://copr.fedorainfracloud.org/coprs/managerforlustre/manager-for-lustre/package/python-iml-agent/status_image/last_build.png)](https://copr.fedorainfracloud.org/coprs/managerforlustre/manager-for-lustre/package/python-iml-agent/)

--- a/chroma_agent/scm_version.py
+++ b/chroma_agent/scm_version.py
@@ -1,4 +1,4 @@
-VERSION = "4.1.1"
+VERSION = "4.1.1-6-ga167f1c"
 PACKAGE_VERSION = "4.1.1"
 BUILD = ""
 IS_RELEASE = False

--- a/python-iml-agent.spec.in
+++ b/python-iml-agent.spec.in
@@ -8,7 +8,7 @@ BuildRequires: systemd
 %{?!package_release: %global package_release @RELEASE@}
 %{?!python_sitelib: %global python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; import sys; sys.stdout.write(get_python_lib())")}
 
-%{?dist_version: %global source https://github.com/intel-hpdd/%{pypi_name}/archive/%{dist_version}.tar.gz}
+%{?dist_version: %global source https://github.com/whamcloud/%{pypi_name}/archive/%{dist_version}.tar.gz}
 %{?dist_version: %global archive_version %{dist_version}}
 %{?!dist_version: %global source https://files.pythonhosted.org/packages/source/i/%{pypi_name}/%{pypi_name}-%{version}.tar.gz}
 %{?!dist_version: %global archive_version %{version}}

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ excludes = ["*tests*"]
 setup(
     name = 'iml-agent',
     version = package_version(),
-    author = "Intel Corporation",
-    author_email = "iml@intel.com",
+    author = "whamCloud Team",
+    author_email = "iml@whamcloud.com",
     url = 'https://pypi.python.org/pypi/iml-agent',
     packages = find_packages(exclude=excludes),
     include_package_data = True,


### PR DESCRIPTION
Fixes #14

In:

https://github.com/whamcloud/iml-agent/blob/a167f1c8e58585c8c75f5ad1489a63b9c44f39a7/chroma_agent/device_plugins/lustre.py#L155-L158

The code is making an assumption that the VDev `Root` `children` will always contain a `Disk`.

This is true for a pool with at least one top-level backing Disk, ex:

```json
     "vdev": {
        "Root": {
          "children": [
            {
              "Disk": {
                "guid": 1031789542385231700,
                "state": "ONLINE",
                "path": "/dev/disk/by-id/dm-uuid-mpath-3600140560ab2b7d5caa4c18a2266b935",
                "dev_id": "dm-uuid-mpath-3600140560ab2b7d5caa4c18a2266b935",
                "phys_path": null,
                "whole_disk": false,
                "is_log": false
              }
            }
          ],
          "spares": [],
          "cache": []
        }
      }
```

but it is not true for any other type of setup.

https://github.com/whamcloud/rust-libzfs/blob/30f5771d56be31d8ece98024276fff030b5a759a/libzfs/src/vdev.rs#L15-L46

Shows the full enum that would need to be accounted for.

The current implementation raises an error like:

```
[07/Jul/2018:03:23:30] console DEBUG Exception raised in sandbox START:
  File "/usr/lib/python2.7/site-packages/iml_common/lib/exception_sandbox.py", line 23, in wrapper
    return function(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/chroma_agent/device_plugins/lustre.py", line 201, in _scan_mounts
    fs_label, fs_uuid, new_device = process_zfs_mount(device, data, zfs_mounts)
  File "/usr/lib/python2.7/site-packages/chroma_agent/device_plugins/lustre.py", line 156, in process_zfs_mount
    child['Disk']['path'] for child in pool['vdev']['Root']['children']
StopIteration
```

While looking at this section, it appears this code is not actually being used on the manager so it should be ok to remove.