### PR TITLE
Remove scan_packages from lustre.py

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,1 +1,1 @@
-This is the Intel® Manager for Lustre* software Monitoring and Adminstration Interface Agent.
+This is the Integrated Manager for Lustre software Monitoring and Adminstration Interface Agent.

--- a/chroma_agent/action_plugins/agent_updates.py
+++ b/chroma_agent/action_plugins/agent_updates.py
@@ -10,13 +10,13 @@ import errno
 
 from chroma_agent.lib.shell import AgentShell
 from chroma_agent.device_plugins.action_runner import CallbackAfterResponse
-from chroma_agent.device_plugins import lustre
 from chroma_agent.log import daemon_log
 from chroma_agent import config
 from chroma_agent.conf import ENV_PATH
 from chroma_agent.crypto import Crypto
 from chroma_agent.lib.yum_utils import yum_util, yum_check_update
 from iml_common.lib.agent_rpc import agent_result, agent_error, agent_result_ok
+from iml_common.lib.service_control import ServiceControl
 
 REPO_PATH = '/etc/yum.repos.d'
 
@@ -125,7 +125,9 @@ def install_packages(repos, packages):
         if error:
             return agent_error(error)
 
-    return agent_result(lustre.scan_packages())
+    ServiceControl.create('iml-update-check').start()
+
+    return agent_result_ok
 
 
 def _check_HYD4050():

--- a/chroma_agent/agent_daemon.py
+++ b/chroma_agent/agent_daemon.py
@@ -49,7 +49,7 @@ class ServerProperties(object):
 def main():
     """handle unexpected exceptions"""
     parser = argparse.ArgumentParser(
-        description="Intel® Manager for Lustre* software Agent")
+        description="Integrated Manager for Lustre software Agent")
 
     parser.add_argument("--publish-zconf", action="store_true")
     parser.parse_args()

--- a/chroma_agent/cli.py
+++ b/chroma_agent/cli.py
@@ -87,7 +87,7 @@ def _register_function(parser, name, fn):
 def main():
     configure_logging()
 
-    parser = argparse.ArgumentParser(description="Intel® Manager for Lustre* software Agent")
+    parser = argparse.ArgumentParser(description="Integrated Manager for Lustre software Agent")
     subparsers = parser.add_subparsers()
 
     for command, fn in ActionPluginManager().commands.items():

--- a/chroma_agent/copytool_monitor.py
+++ b/chroma_agent/copytool_monitor.py
@@ -278,7 +278,7 @@ class GetCopytoolAction(Action):
 
 
 def main():
-    parser = ArgumentParser(description="Intel® Manager for Lustre* software Copytool Monitor")
+    parser = ArgumentParser(description="Integrated Manager for Lustre* software Copytool Monitor")
     parser.add_argument("copytool_id", action=GetCopytoolAction)
     args = parser.parse_args()
 

--- a/chroma_agent/device_plugins/lustre.py
+++ b/chroma_agent/device_plugins/lustre.py
@@ -29,104 +29,6 @@ from chroma_agent.device_plugins.audit import local
 
 VersionInfo = namedtuple('VersionInfo', ['epoch', 'version', 'release', 'arch'])
 
-REPO_PATH = "/etc/yum.repos.d/Intel-Lustre-Agent.repo"
-
-# import so that this module can be imported in pure python environments as well as on Linux.
-# Doing it this way means that rpm_lib can mocked.
-try:
-    import rpm as rpm_lib
-except:
-    rpm_lib = None
-
-
-@exceptionSandBox(console_log, None)
-def scan_packages():
-    """
-    Interrogate the packages available from configured repositories, and the installation
-    status of those packages.
-    """
-
-    # Look up what repos are configured
-    # =================================
-    if not os.path.exists(REPO_PATH):
-        return None
-
-    cp = ConfigParser.SafeConfigParser()
-    cp.read(REPO_PATH)
-    repo_names = sorted(cp.sections())
-    repo_packages = dict([(name, defaultdict(lambda: {'available': [], 'installed': []})) for name in repo_names])
-
-    # For all repos, enumerate packages in the repo in alphabetic order
-    # =================================================================
-    yum_util('clean', fromrepo=repo_names)
-
-    # For all repos, query packages in alphabetical order
-    # ===================================================
-    for repo_name in repo_names:
-        packages = repo_packages[repo_name]
-        try:
-            stdout = yum_util('repoquery', fromrepo=[repo_name])
-
-            # Returning nothing means the package was not found at all and so we have no data to deliver back.
-            if stdout:
-                for line in [l.strip() for l in stdout.strip().split("\n")]:
-                    if line.startswith("Last metadata expiration check") or \
-                        line.startswith("Waiting for process with pid"):
-                        continue
-                    epoch, name, version, release, arch = line.split()
-                    if arch == "src":
-                        continue
-                    packages[name]['available'].append(VersionInfo(
-                        epoch=epoch,
-                        version=version,
-                        release=release,
-                        arch=arch))
-        except ValueError, e:
-            console_log.error("bug HYD-2948. repoquery Output: %s" % (stdout))
-            raise e
-        except RuntimeError, e:
-            # This is a network operation, so cope with it failing
-            daemon_log.error(e)
-            return None
-
-    # For all packages named in the repos, get installed version if it is installed
-    # =============================================================================
-    updates_available = []
-    ts = rpm_lib.TransactionSet()
-    for repo_name, packages in repo_packages.items():
-        for package_name, package_data in packages.items():
-            headers = ts.dbMatch('name', package_name)
-            for h in headers:
-                package_data['installed'].append(VersionInfo(
-                    epoch=h['epochnum'].__str__(),
-                    version=h['version'],
-                    release=h['release'],
-                    arch=h['arch']
-                ))
-                installed = package_data['installed'][0]
-                for available in package_data['available']:
-                    if rpm_lib.labelCompare((available.epoch,
-                                             available.version,
-                                             available.release),
-                                            (installed.epoch,
-                                             installed.version,
-                                             installed.release)) > 0:
-                        updates_available.append("%s:%s-%s-%s-%s" %
-                                                 (repo_name,
-                                                  package_name,
-                                                  available.version,
-                                                  available.release,
-                                                  available.arch))
-                        break
-
-    # log available updates for updates notification debugging
-    if updates_available:
-        console_log.info("scan_packages: updates available: %s" %
-                         updates_available)
-
-    return repo_packages
-
-
 def process_zfs_mount(device, data, zfs_mounts):
     # If zfs-backed target/dataset, lookup underlying pool to get uuid
     # and nested dataset in zed structures to access lustre svname (label).
@@ -173,7 +75,7 @@ def process_lvm_mount(device, data):
 
 
 class LustrePlugin(DevicePlugin):
-    delta_fields = ['capabilities', 'properties', 'mounts', 'packages', 'resource_locations']
+    delta_fields = ['capabilities', 'properties', 'mounts', 'resource_locations']
 
     def __init__(self, session):
         self.reset_state()
@@ -261,11 +163,6 @@ class LustrePlugin(DevicePlugin):
 
         mounts = self._scan_mounts()
 
-        if initial:
-            packages = scan_packages()
-        else:
-            packages = None
-
         # FIXME: HYD-1095 we should be sending a delta instead of a full dump every time
         # FIXME: At this time the 'capabilities' attribute is unused on the manager
         return {
@@ -275,7 +172,6 @@ class LustrePlugin(DevicePlugin):
             "metrics": audit.metrics(),
             "properties": audit.properties(),
             "mounts": mounts,
-            "packages": packages,
             "resource_locations": resource_locations
         }
 

--- a/chroma_agent/fence_chroma.py
+++ b/chroma_agent/fence_chroma.py
@@ -59,9 +59,9 @@ Arguments read from standard input take the form of:
 
     if ns.action == "metadata":
         print """<?xml version="1.0" ?>
-<resource-agent name="fence_chroma" shortdesc="Fence agent for Intel(R) Manager for Lustre* software Storage Servers">
-<longdesc>fence_chroma is an I/O Fencing agent which can be used with Intel(R) Manager for Lustre* software Storage Servers.</longdesc>
-<vendor-url>http://www.intel.com</vendor-url>
+<resource-agent name="fence_chroma" shortdesc="Fence agent for Integrated Manager for Lustre software Storage Servers">
+<longdesc>fence_chroma is an I/O Fencing agent which can be used with Integrated Manager for Lustre software Storage Servers.</longdesc>
+<vendor-url>http://www.whamCloud.com</vendor-url>
 <parameters>
     <parameter name="port">
         <getopt mixed="-p" />

--- a/chroma_agent/templates/chroma-copytool
+++ b/chroma_agent/templates/chroma-copytool
@@ -12,7 +12,7 @@ COPYTOOL_ID="{{ id }}"
 DAEMON_BIN="{{ ct_path }}"
 COPYTOOL_ARGUMENTS="{{ ct_arguments }}"
 
-SVC_NAME="Intel Manager For Lustre Copytool"
+SVC_NAME="Integrated Manager For Lustre Copytool"
 PID_FILE=/var/run/copytool-${COPYTOOL_ID}.pid
 
 start() {

--- a/chroma_agent/templates/chroma-copytool-monitor
+++ b/chroma_agent/templates/chroma-copytool-monitor
@@ -10,7 +10,7 @@
 
 COPYTOOL_ID="{{ id }}"
 
-SVC_NAME="Intel Manager For Lustre Copytool Monitor"
+SVC_NAME="Integrated Manager For Lustre Copytool Monitor"
 PID_FILE=/var/run/chroma-copytool-monitor-${COPYTOOL_ID}.pid
 DAEMON_BIN=/usr/sbin/chroma-copytool-monitor
 

--- a/python-iml-agent.spec.in
+++ b/python-iml-agent.spec.in
@@ -30,12 +30,12 @@ Group:          Development/Libraries
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 Prefix:         %{_prefix}
 BuildArch:      noarch
-Vendor:         Intel Corporation <hpdd-info@intel.com>
+Vendor:         whamCloud <iml@whamcloud.com>
 BuildRequires:  python2-setuptools
 BuildRequires:  systemd
 
 %description
-This is the Intel Manager for Lustre monitoring and adminstration agent
+This is the Integrated Manager for Lustre monitoring and adminstration agent
 
 %package -n     python2-%{pypi_name}
 Summary:        %{summary}
@@ -55,6 +55,7 @@ Requires:       systemd-python
 Requires:       python-tzlocal
 Requires:       python2-toolz
 Requires:       iml-device-scanner-proxy < 3
+Requires:       iml-update-check < 2
 Requires:       util-linux-ng
 Requires(post): selinux-policy
 Requires:       dnf
@@ -63,7 +64,7 @@ Requires:       python-urllib3
 %{?python_provide:%python_provide python2-%{pypi_name}}
 
 %description -n python2-%{pypi_name}
-This is the Intel Manager for Lustre monitoring and adminstration agent
+This is the Integrated Manager for Lustre monitoring and adminstration agent
 
 %package -n     python2-%{pypi_name}-management
 Summary:        Management functionality layer.
@@ -87,7 +88,7 @@ Requires:       fence-agents
 Requires:       fence-agents-virsh
 
 %description -n python2-%{pypi_name}-management
-This package layers on management capabilities for Intel Manager for Lustre Agent.
+This package layers on management capabilities for Integrated Manager for Lustre Agent.
 
 %prep
 %if %{?dist_version:1}%{!?dist_version:0}
@@ -191,7 +192,10 @@ grubby --set-default=/boot/vmlinuz-$MOST_RECENT_KERNEL_VERSION
 %defattr(-,root,root)
 
 %changelog
-* Fri Dec  1 2017 Brian J. Murrell <brian.murrell@intel.com> - 4.0.5.0-1
+* Mon Jul 16 2018 Joe Grund <jgrund@whamcloud.com> - 4.1.1.0-1
+Remove old package update scan from this project.
+
+* Fri Dec 1 2017 Brian J. Murrell <brian.murrell@intel.com> - 4.0.5.0-1
 - Initial module
   * split out from the intel-manager-for-lustre project
 

--- a/tests/actions_plugins/test_agent_updates.py
+++ b/tests/actions_plugins/test_agent_updates.py
@@ -5,7 +5,6 @@ from tempfile import NamedTemporaryFile
 from mock import patch
 
 from chroma_agent.action_plugins import agent_updates
-from chroma_agent.device_plugins import lustre
 from chroma_agent import config
 from iml_common.lib.shell import Shell
 from iml_common.test.command_capture_testcase import CommandCaptureTestCase, CommandCaptureCommand
@@ -17,14 +16,9 @@ class TestManageUpdates(CommandCaptureTestCase):
         super(TestManageUpdates, self).setUp()
         self.tmpRepo = NamedTemporaryFile(delete=False)
 
-        self.old_scan_packages = lustre.scan_packages
-        lustre.scan_packages = mock.Mock(return_value={})
-
     def tearDown(self):
         if os.path.exists(self.tmpRepo.name):
             os.remove(self.tmpRepo.name)
-
-        lustre.scan_packages = self.old_scan_packages
 
     def test_configure_repo(self):
         import chroma_agent

--- a/tests/test_fencing.py
+++ b/tests/test_fencing.py
@@ -15,8 +15,8 @@ cib_configured_result = '''<cib epoch="99" num_updates="1" admin_epoch="0" valid
         <nvpair id="cib-bootstrap-options-symmetric-cluster" name="symmetric-cluster" value="true"/>
         <nvpair id="cib-bootstrap-options-stonith-enabled" name="stonith-enabled" value="true"/>
       </cluster_property_set>
-      <cluster_property_set id="intel_manager_for_lustre_configuration">
-        <nvpair id="intel_manager_for_lustre_configuration_configured_by" name="configured_by" value="lotus-33vm15"/>
+      <cluster_property_set id="integrated_manager_for_lustre_configuration">
+        <nvpair id="integrated_manager_for_lustre_configuration_configured_by" name="configured_by" value="lotus-33vm15"/>
       </cluster_property_set>
     </crm_config>
   </configuration>


### PR DESCRIPTION
Now that we have iml-update-check set to trigger once a day, we can
remove the explicit, imperative scanning for packages. When we need to
explicitly trigger a scan we can just invoke the systemd unit.

  - Remove scan_packages and surrounding code.
  - Remove some more Intel references.