### PR TITLE
Update units

### DIFF
--- a/10-device-scanner.socket.conf
+++ b/10-device-scanner.socket.conf
@@ -1,2 +1,0 @@
-[Unit]
-PartOf=iml-storage-server.target

--- a/10-device-scanner.target.conf
+++ b/10-device-scanner.target.conf
@@ -1,3 +1,2 @@
 [Unit]
 PartOf=iml-storage-server.target
-Before=iml-storage-server.target

--- a/chroma-agent.service
+++ b/chroma-agent.service
@@ -1,8 +1,7 @@
 [Unit]
 Description=IML Agent Daemon
 After=network.target
-After=device-scanner.socket
-Requires=device-scanner.socket
+After=device-scanner.target
 PartOf=iml-storage-server.target
 
 [Service]

--- a/chroma_agent/action_plugins/agent_setup.py
+++ b/chroma_agent/action_plugins/agent_setup.py
@@ -33,17 +33,12 @@ def deregister_server():
     conf.remove_server_url()
 
     def disable_and_kill():
-        console_log.info("Disabling iml-storage-server units")
-
-        map(lambda x: ServiceControl.create(x).disable(), [
-            'device-scanner.socket',
-            'mount-emitter.service',
-            'swap-emitter.service',
-            'scanner-proxy.path'
-        ])
-
         console_log.info("Terminating")
-        ServiceControl.create('iml-storage-server.target').stop()
+
+        storage_server_target = ServiceControl.create('iml-storage-server.target')
+        storage_server_target.disable()
+        storage_server_target.stop()
+
 
     raise CallbackAfterResponse(None, disable_and_kill)
 

--- a/iml-storage-server.target
+++ b/iml-storage-server.target
@@ -1,5 +1,13 @@
 [Unit]
 Description=IML Storage Server Service Target
-Before=chroma-agent.service
-Wants=device-scanner.target
-Wants=iml-update-check.timer
+Requires=chroma-agent.service
+After=chroma-agent.service
+Requires=device-scanner.target
+After=device-scanner.target
+Requires=iml-update-check.timer
+
+[Install]
+WantedBy=multi-user.target
+Also=device-scanner.target
+Also=chroma-agent.service
+Also=iml-update-check.timer

--- a/python-iml-agent.spec.in
+++ b/python-iml-agent.spec.in
@@ -25,7 +25,6 @@ Source2:        50-chroma-agent.preset
 Source3:        logrotate.cfg
 Source4:        iml-storage-server.target
 Source5:        10-device-scanner.target.conf
-Source6:        10-device-scanner.socket.conf
 Group:          Development/Libraries
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 Prefix:         %{_prefix}
@@ -117,8 +116,6 @@ install -m 644 %{SOURCE3} $RPM_BUILD_ROOT/etc/logrotate.d/chroma-agent
 install -m 644 %{SOURCE4} %{buildroot}%{_unitdir}/iml-storage-server.target
 mkdir -p %{buildroot}%{_unitdir}/device-scanner.target.d/
 install -m 644 %{SOURCE5} %{buildroot}%{_unitdir}/device-scanner.target.d/10-device-scanner.target.conf
-mkdir -p %{buildroot}%{_unitdir}/device-scanner.socket.d/
-install -m 644 %{SOURCE6} %{buildroot}%{_unitdir}/device-scanner.socket.d/10-device-scanner.socket.conf
 
 touch management.files
 cat <<EndOfList>>management.files
@@ -183,7 +180,6 @@ grubby --set-default=/boot/vmlinuz-$MOST_RECENT_KERNEL_VERSION
 %attr(0644,root,root)%{_presetdir}/50-chroma-agent.preset
 %attr(0644,root,root)%{_unitdir}/iml-storage-server.target
 %attr(0644,root,root)%{_unitdir}/device-scanner.target.d/10-device-scanner.target.conf
-%attr(0644,root,root)%{_unitdir}/device-scanner.socket.d/10-device-scanner.socket.conf
 %{_bindir}/chroma-agent*
 %{python_sitelib}/%(a=%{pypi_name}; echo ${a//-/_})-*.egg-info/*
 %attr(0644,root,root)/etc/logrotate.d/chroma-agent


### PR DESCRIPTION
Now that device-scanner.target groups all device-scanner services, we
should use that instead of device-scanner.socket.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>
