### PR TITLE
Fix URL's

### DIFF
--- a/chroma_agent/agent_daemon.py
+++ b/chroma_agent/agent_daemon.py
@@ -65,7 +65,7 @@ def main():
     try:
         daemon_log.info("Entering main loop")
         try:
-            url = urljoin(os.environ["IML_MANAGER_URL"], "agent/message")
+            url = urljoin(os.environ["IML_MANAGER_URL"], "agent/message/")
         except KeyError as e:
             daemon_log.error(
                 "No configuration found (must be registered before running the agent service), "

--- a/chroma_agent/agent_daemon.py
+++ b/chroma_agent/agent_daemon.py
@@ -11,6 +11,8 @@ import argparse
 import signal
 import socket
 
+from urlparse import urljoin
+
 from chroma_agent import config
 from chroma_agent.conf import ENV_PATH
 from chroma_agent.crypto import Crypto
@@ -63,7 +65,7 @@ def main():
     try:
         daemon_log.info("Entering main loop")
         try:
-            url = os.environ["IML_MANAGER_URL"] + 'agent/message/'
+            url = urljoin(os.environ["IML_MANAGER_URL"], "agent/message")
         except KeyError as e:
             daemon_log.error(
                 "No configuration found (must be registered before running the agent service), "

--- a/chroma_agent/copytool_monitor.py
+++ b/chroma_agent/copytool_monitor.py
@@ -14,6 +14,7 @@ import select
 import json
 
 from argparse import ArgumentParser, ArgumentError, Action
+from urlparse import urljoin
 
 from chroma_agent import config
 from chroma_agent.conf import ENV_PATH
@@ -285,7 +286,7 @@ def main():
     copytool_log_setup()
 
     try:
-        manager_url = os.environ["IML_MANAGER_URL"] + "agent/copytool_event/"
+        manager_url = urljoin(os.environ["IML_MANAGER_URL"], "agent/copytool_event")
     except KeyError:
         copytool_log.error("No configuration found (must be configured before starting a copytool monitor)")
         sys.exit(1)

--- a/chroma_agent/lib/corosync.py
+++ b/chroma_agent/lib/corosync.py
@@ -10,6 +10,7 @@ import socket
 from jinja2 import Environment, PackageLoader
 from netaddr import IPNetwork, IPAddress
 from netaddr.core import AddrFormatError
+from urlparse import urljoin
 
 from chroma_agent import config
 from chroma_agent.lib import node_admin
@@ -58,7 +59,7 @@ def generate_ring1_network(ring0):
 def get_ring0():
     # ring0 will always be on the interface used for agent->manager comms
     from urlparse import urlparse
-    server_url = os.environ["IML_MANAGER_URL"] + 'agent/'
+    server_url = urljoin(os.environ["IML_MANAGER_URL"], "agent")
     manager_address = socket.gethostbyname(urlparse(server_url).hostname)
     out = AgentShell.try_run(['/sbin/ip', 'route', 'get', manager_address])
     match = re.search(r'dev\s+([^\s]+)', out)

--- a/chroma_agent/scm_version.py
+++ b/chroma_agent/scm_version.py
@@ -1,4 +1,4 @@
-VERSION = "4.1.1-6-ga167f1c"
+VERSION = "4.1.1-25-g323fc26"
 PACKAGE_VERSION = "4.1.1"
 BUILD = ""
 IS_RELEASE = False

--- a/chroma_agent/scm_version.py
+++ b/chroma_agent/scm_version.py
@@ -1,4 +1,4 @@
-VERSION = "4.1.1-25-g323fc26"
+VERSION = "4.1.1-25-gc2e16cc"
 PACKAGE_VERSION = "4.1.1"
 BUILD = ""
 IS_RELEASE = False


### PR DESCRIPTION
The urls constructed in the agent_daemon, corosync, and copytool_monitor
will create a link with multiple slashes. For example:

https://nginx:7443//agent/message

This will cause issues with nginx if the proxy_pass is using a variable
instead of a static url. Update each of these urls such that the paths
are joined properly.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>