### PR TITLE
Rebrand Intel to IML

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 DDN
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,7 +1,0 @@
-Copyright (c) 2013 Intel Corproration. All Rights Reserved.
-
-This software is the confidential and proprietary information of
-Intel Corporation ("Confidential Information").  You shall not disclose
-such Confidential Information and shall use it only in accordance with
-the terms of the license agreement you entered into with
-Intel Corporation.

--- a/chroma_agent/templates/corosync.conf
+++ b/chroma_agent/templates/corosync.conf
@@ -1,4 +1,4 @@
-# Autoconfigured by Intel Manager for Lustre
+# Autoconfigured by Integrated Manager for Lustre
 # DO NOT EDIT -- CHANGES MADE HERE WILL BE LOST
 compatibility: whitetank
 

--- a/chroma_agent/templates/ifcfg-nic
+++ b/chroma_agent/templates/ifcfg-nic
@@ -1,4 +1,4 @@
-# Autoconfigured by Intel Manager for Lustre
+# Autoconfigured by Integrated Manager for Lustre
 DEVICE="{{ device }}"
 BOOTPROTO="STATIC"
 HWADDR="{{ mac_address }}"

--- a/tests/actions_plugins/test_agent_updates.py
+++ b/tests/actions_plugins/test_agent_updates.py
@@ -23,8 +23,8 @@ class TestManageUpdates(CommandCaptureTestCase):
     def test_configure_repo(self):
         import chroma_agent
         expected_content = """
-[Intel-Lustre-Manager]
-name=Intel Lustre Manager updates
+[Integrated-Manager-For-Lustre]
+name=Integrated Manager for Lustre updates
 baseurl=http://www.test.com/test.repo
 enabled=1
 gpgcheck=0
@@ -34,8 +34,8 @@ sslclientkey = /etc/iml/private.pem
 sslclientcert = /etc/iml/self.crt
 """
         provided_content = """
-[Intel-Lustre-Manager]
-name=Intel Lustre Manager updates
+[Integrated-Manager-For-Lustre]
+name=Integrated Manager for Lustre updates
 baseurl=http://www.test.com/test.repo
 enabled=1
 gpgcheck=0


### PR DESCRIPTION
Remove all Intel branding and replace with Intel Manager for Lustre.
Fix LICENSE file.

Signed-off-by: Nathaniel Clark <nclark@whamcloud.com>