### PR TITLE
Use Lustre/ZFS instead of chroma:Target resource agents

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include LICENSE.txt
 include Target
+include ZFS
 include logrotate.cfg
 include chroma_agent/templates/corosync.conf
 include chroma_agent/templates/ifcfg-nic

--- a/README.md
+++ b/README.md
@@ -5,3 +5,6 @@ The Manager for Lustre Agent
 [![Build Status](https://travis-ci.org/whamcloud/iml-agent.svg?branch=master)](https://travis-ci.org/whamcloud/iml-agent)
 
 [![Build Status](https://copr.fedorainfracloud.org/coprs/managerforlustre/manager-for-lustre/package/python-iml-agent/status_image/last_build.png)](https://copr.fedorainfracloud.org/coprs/managerforlustre/manager-for-lustre/package/python-iml-agent/)
+
+[ZFS Resource Agent](https://github.com/ClusterLabs/resource-agents/blob/master/heartbeat/ZFS)
+When the resource-agents release 4.0.1 is available widely, this can be phased out or become a symlink.

--- a/ZFS
+++ b/ZFS
@@ -1,0 +1,192 @@
+#!/bin/sh
+#
+# License:      GNU General Public License (GPL)
+# Support:      zfs@lists.illumos.org
+# Written by:   Saso Kiselkov
+#
+#	This script manages ZFS pools
+#	It can import a ZFS pool or export it
+#
+#	usage: $0 {start|stop|status|monitor|validate-all|meta-data}
+#
+#	The "start" arg imports a ZFS pool.
+#	The "stop" arg exports it.
+#
+#       OCF parameters are as follows
+#       OCF_RESKEY_pool - the pool to import/export
+#
+#######################################################################
+# Initialization:
+
+: ${OCF_FUNCTIONS_DIR=${OCF_ROOT}/lib/heartbeat}
+. ${OCF_FUNCTIONS_DIR}/ocf-shellfuncs
+
+# Defaults
+OCF_RESKEY_importforce_default=true
+
+: ${OCF_RESKEY_importforce=${OCF_RESKEY_importforce_default}}
+
+USAGE="usage: $0 {start|stop|status|monitor|validate-all|meta-data}";
+
+#######################################################################
+
+meta_data() {
+        cat <<END
+<?xml version="1.0"?>
+<!DOCTYPE resource-agent SYSTEM "ra-api-1.dtd">
+<resource-agent name="ZFS">
+<version>1.0</version>
+<longdesc lang="en">
+This script manages ZFS pools
+It can import a ZFS pool or export it
+</longdesc>
+<shortdesc lang="en">Manages ZFS pools</shortdesc>
+
+<parameters>
+<parameter name="pool" unique="1" required="1">
+<longdesc lang="en">
+The name of the ZFS pool to manage, e.g. "tank".
+</longdesc>
+<shortdesc lang="en">ZFS pool name</shortdesc>
+<content type="string" default="" />
+</parameter>
+<parameter name="importargs" unique="0" required="0">
+<longdesc lang="en">
+Arguments to zpool import, e.g. "-d /dev/disk/by-id".
+</longdesc>
+<shortdesc lang="en">Import arguments</shortdesc>
+<content type="string" default="" />
+</parameter>
+<parameter name="importforce" unique="1" required="0">
+<longdesc lang="en">
+zpool import is given the -f option.
+</longdesc>
+<shortdesc lang="en">Import is forced</shortdesc>
+<content type="boolean" default="${OCF_RESKEY_importforce_default}" />
+</parameter>
+</parameters>
+
+<actions>
+<action name="start"   timeout="60s" />
+<action name="stop"    timeout="60s" />
+<action name="monitor" depth="0"  timeout="30s" interval="5s" />
+<action name="validate-all"  timeout="30s" />
+<action name="meta-data"  timeout="5s" />
+</actions>
+</resource-agent>
+END
+        exit $OCF_SUCCESS
+}
+
+zpool_is_imported () {
+    zpool list -H "$OCF_RESKEY_pool" > /dev/null
+}
+
+# Forcibly imports a ZFS pool, mounting all of its auto-mounted filesystems
+# (as configured in the 'mountpoint' and 'canmount' properties)
+# If the pool is already imported, no operation is taken.
+zpool_import () {
+    if ! zpool_is_imported; then
+        ocf_log debug "${OCF_RESKEY_pool}:starting import"
+
+        # The meanings of the options to import are as follows:
+        #   -f : import even if the pool is marked as imported to another
+        #        system - the system may have failed and not exported it
+        #        cleanly.
+        #   -o cachefile=none : the import should be temporary, so do not
+        #        cache it persistently (across machine reboots). We want
+        #        the CRM to explicitly control imports of this pool.
+	if ocf_is_true "${OCF_RESKEY_importforce}"; then
+	    FORCE=-f
+	else
+	    FORCE=""
+	fi
+        if zpool import $FORCE $OCF_RESKEY_importargs -o cachefile=none "$OCF_RESKEY_pool" ; then
+            ocf_log debug "${OCF_RESKEY_pool}:import successful"
+            return $OCF_SUCCESS
+        else
+            ocf_log debug "${OCF_RESKEY_pool}:import failed"
+            return $OCF_ERR_GENERIC
+        fi
+    fi
+}
+
+# Forcibly exports a ZFS pool, unmounting all of its filesystems in the process
+# If the pool is not imported, no operation is taken.
+zpool_export () {
+    if zpool_is_imported; then
+        ocf_log debug "${OCF_RESKEY_pool}:starting export"
+
+        # -f : force the export, even if we have mounted filesystems
+        # Please note that this may fail with a "busy" error if there are
+        # other kernel subsystems accessing the pool (e.g. SCSI targets).
+        # Always make sure the pool export is last in your failover logic.
+        if zpool export -f "$OCF_RESKEY_pool" ; then
+            ocf_log debug "${OCF_RESKEY_pool}:export successful"
+            return $OCF_SUCCESS
+	else
+            ocf_log debug "${OCF_RESKEY_pool}:export failed"
+            return $OCF_ERR_GENERIC
+	fi
+    fi
+}
+
+# Monitors the health of a ZFS pool resource. Please note that this only
+# checks whether the pool is imported and functional, not whether it has
+# any degraded devices (use monitoring systems such as Zabbix for that).
+zpool_monitor () {
+    # If the pool is not imported, then we can't monitor its health
+    if ! zpool_is_imported; then
+        return $OCF_NOT_RUNNING
+    fi
+
+    # Check the pool status
+    HEALTH=$(zpool list -H -o health "$OCF_RESKEY_pool")
+    case "$HEALTH" in
+        ONLINE|DEGRADED) return $OCF_SUCCESS;;
+        FAULTED)         return $OCF_NOT_RUNNING;;
+        *)               return $OCF_ERR_GENERIC;;
+    esac
+}
+
+# Validates whether we can import a given ZFS pool
+zpool_validate () {
+    # Check that the 'zpool' command is known
+    if ! which zpool > /dev/null; then
+        return $OCF_ERR_INSTALLED
+    fi
+
+    # If the pool is imported, then it is obviously valid
+    if zpool_is_imported; then
+        return $OCF_SUCCESS
+    fi
+
+    # Check that the pool can be imported
+    if zpool import $OCF_RESKEY_importargs | grep 'pool:' | grep "\\<$OCF_RESKEY_pool\\>" > /dev/null;
+    then
+        return $OCF_SUCCESS
+    else
+        return $OCF_ERR_CONFIGURED
+    fi
+}
+
+usage () {
+    echo "$USAGE" >&2
+    return $1
+}
+
+if [ $# -ne 1 ]; then
+    usage $OCF_ERR_ARGS
+fi
+
+case $1 in
+    meta-data)		meta_data;;
+    start)		zpool_import;;
+    stop)		zpool_export;;
+    status|monitor)	zpool_monitor;;
+    validate-all)	zpool_validate;;
+    usage)		usage $OCF_SUCCESS;;
+    *)			usage $OCF_ERR_UNIMPLEMENTED;;
+esac
+
+exit $?

--- a/ZFS
+++ b/ZFS
@@ -31,7 +31,7 @@ USAGE="usage: $0 {start|stop|status|monitor|validate-all|meta-data}";
 #######################################################################
 
 meta_data() {
-        cat <<END
+	cat <<END
 <?xml version="1.0"?>
 <!DOCTYPE resource-agent SYSTEM "ra-api-1.dtd">
 <resource-agent name="ZFS">
@@ -75,118 +75,125 @@ zpool import is given the -f option.
 </actions>
 </resource-agent>
 END
-        exit $OCF_SUCCESS
+	exit $OCF_SUCCESS
 }
 
 zpool_is_imported () {
-    zpool list -H "$OCF_RESKEY_pool" > /dev/null
+	zpool list -H "$OCF_RESKEY_pool" > /dev/null
 }
 
 # Forcibly imports a ZFS pool, mounting all of its auto-mounted filesystems
 # (as configured in the 'mountpoint' and 'canmount' properties)
 # If the pool is already imported, no operation is taken.
 zpool_import () {
-    if ! zpool_is_imported; then
-        ocf_log debug "${OCF_RESKEY_pool}:starting import"
+	if ! zpool_is_imported; then
+		ocf_log debug "${OCF_RESKEY_pool}:starting import"
 
-        # The meanings of the options to import are as follows:
-        #   -f : import even if the pool is marked as imported to another
-        #        system - the system may have failed and not exported it
-        #        cleanly.
-        #   -o cachefile=none : the import should be temporary, so do not
-        #        cache it persistently (across machine reboots). We want
-        #        the CRM to explicitly control imports of this pool.
+		# The meanings of the options to import are as follows:
+		#   -f : import even if the pool is marked as imported to another
+		#        system - the system may have failed and not exported it
+		#        cleanly.
+		#   -o cachefile=none : the import should be temporary, so do not
+		#        cache it persistently (across machine reboots). We want
+		#        the CRM to explicitly control imports of this pool.
 	if ocf_is_true "${OCF_RESKEY_importforce}"; then
-	    FORCE=-f
+		FORCE=-f
 	else
-	    FORCE=""
+		FORCE=""
 	fi
-        if zpool import $FORCE $OCF_RESKEY_importargs -o cachefile=none "$OCF_RESKEY_pool" ; then
-            ocf_log debug "${OCF_RESKEY_pool}:import successful"
-            return $OCF_SUCCESS
-        else
-            ocf_log debug "${OCF_RESKEY_pool}:import failed"
-            return $OCF_ERR_GENERIC
-        fi
-    fi
+		if zpool import $FORCE $OCF_RESKEY_importargs -o cachefile=none "$OCF_RESKEY_pool" ; then
+			ocf_log debug "${OCF_RESKEY_pool}:import successful"
+			return $OCF_SUCCESS
+		else
+			ocf_log debug "${OCF_RESKEY_pool}:import failed"
+			return $OCF_ERR_GENERIC
+		fi
+	fi
 }
 
 # Forcibly exports a ZFS pool, unmounting all of its filesystems in the process
 # If the pool is not imported, no operation is taken.
 zpool_export () {
-    if zpool_is_imported; then
-        ocf_log debug "${OCF_RESKEY_pool}:starting export"
+	if zpool_is_imported; then
+		ocf_log debug "${OCF_RESKEY_pool}:starting export"
 
-        # -f : force the export, even if we have mounted filesystems
-        # Please note that this may fail with a "busy" error if there are
-        # other kernel subsystems accessing the pool (e.g. SCSI targets).
-        # Always make sure the pool export is last in your failover logic.
-        if zpool export -f "$OCF_RESKEY_pool" ; then
-            ocf_log debug "${OCF_RESKEY_pool}:export successful"
-            return $OCF_SUCCESS
-	else
-            ocf_log debug "${OCF_RESKEY_pool}:export failed"
-            return $OCF_ERR_GENERIC
+		# -f : force the export, even if we have mounted filesystems
+		# Please note that this may fail with a "busy" error if there are
+		# other kernel subsystems accessing the pool (e.g. SCSI targets).
+		# Always make sure the pool export is last in your failover logic.
+		if zpool export -f "$OCF_RESKEY_pool" ; then
+			ocf_log debug "${OCF_RESKEY_pool}:export successful"
+			return $OCF_SUCCESS
+        else
+			ocf_log debug "${OCF_RESKEY_pool}:export failed"
+			return $OCF_ERR_GENERIC
+        fi
 	fi
-    fi
 }
 
 # Monitors the health of a ZFS pool resource. Please note that this only
 # checks whether the pool is imported and functional, not whether it has
 # any degraded devices (use monitoring systems such as Zabbix for that).
 zpool_monitor () {
-    # If the pool is not imported, then we can't monitor its health
-    if ! zpool_is_imported; then
-        return $OCF_NOT_RUNNING
-    fi
+	# If the pool is not imported, then we can't monitor its health
+	if ! zpool_is_imported; then
+		return $OCF_NOT_RUNNING
+	fi
 
-    # Check the pool status
-    HEALTH=$(zpool list -H -o health "$OCF_RESKEY_pool")
-    case "$HEALTH" in
-        ONLINE|DEGRADED) return $OCF_SUCCESS;;
-        FAULTED)         return $OCF_NOT_RUNNING;;
-        *)               return $OCF_ERR_GENERIC;;
-    esac
+	# Check the pool status
+	# Since version 0.7.10 status can be obtained without locks
+	# https://github.com/zfsonlinux/zfs/pull/7563
+	if [ -f /proc/spl/kstat/zfs/$OCF_RESKEY_pool/state ] ; then
+		HEALTH=$(</proc/spl/kstat/zfs/$OCF_RESKEY_pool/state)
+	else
+		HEALTH=$(zpool list -H -o health "$OCF_RESKEY_pool")
+	fi
+
+	case "$HEALTH" in
+		ONLINE|DEGRADED) return $OCF_SUCCESS;;
+		FAULTED)         return $OCF_NOT_RUNNING;;
+		*)               return $OCF_ERR_GENERIC;;
+	esac
 }
 
 # Validates whether we can import a given ZFS pool
 zpool_validate () {
-    # Check that the 'zpool' command is known
-    if ! which zpool > /dev/null; then
-        return $OCF_ERR_INSTALLED
-    fi
+	# Check that the 'zpool' command is known
+	if ! which zpool > /dev/null; then
+		return $OCF_ERR_INSTALLED
+	fi
 
-    # If the pool is imported, then it is obviously valid
-    if zpool_is_imported; then
-        return $OCF_SUCCESS
-    fi
+	# If the pool is imported, then it is obviously valid
+	if zpool_is_imported; then
+		return $OCF_SUCCESS
+	fi
 
-    # Check that the pool can be imported
-    if zpool import $OCF_RESKEY_importargs | grep 'pool:' | grep "\\<$OCF_RESKEY_pool\\>" > /dev/null;
-    then
-        return $OCF_SUCCESS
-    else
-        return $OCF_ERR_CONFIGURED
-    fi
+	# Check that the pool can be imported
+	if zpool import $OCF_RESKEY_importargs | grep 'pool:' | grep "\\<$OCF_RESKEY_pool\\>" > /dev/null;
+	then
+		return $OCF_SUCCESS
+	else
+		return $OCF_ERR_CONFIGURED
+	fi
 }
 
 usage () {
-    echo "$USAGE" >&2
-    return $1
+	echo "$USAGE" >&2
+	return $1
 }
 
 if [ $# -ne 1 ]; then
-    usage $OCF_ERR_ARGS
+	usage $OCF_ERR_ARGS
 fi
 
 case $1 in
-    meta-data)		meta_data;;
-    start)		zpool_import;;
-    stop)		zpool_export;;
-    status|monitor)	zpool_monitor;;
-    validate-all)	zpool_validate;;
-    usage)		usage $OCF_SUCCESS;;
-    *)			usage $OCF_ERR_UNIMPLEMENTED;;
+	meta-data)      meta_data;;
+	start)          zpool_import;;
+	stop)           zpool_export;;
+	status|monitor) zpool_monitor;;
+	validate-all)   zpool_validate;;
+	usage)          usage $OCF_SUCCESS;;
+	*)              usage $OCF_ERR_UNIMPLEMENTED;;
 esac
 
 exit $?

--- a/chroma_agent/action_plugins/manage_targets.py
+++ b/chroma_agent/action_plugins/manage_targets.py
@@ -239,11 +239,11 @@ def _mkdir_p_concurrent(path):
     def mkdir_silent(path):
         try:
             os.makedirs(path)
-        except OSError, e:
-            if e.errno == errno.EEXIST:
+        except OSError, err:
+            if err.errno == errno.EEXIST:
                 pass
             else:
-                raise e
+                raise err
 
     parent = os.path.split(path)[0]
     mkdir_silent(parent)
@@ -327,11 +327,8 @@ def configure_target_store(device, uuid, mount_point, backfstype, device_type):
                                     'backfstype': backfstype,
                                     'device_type': device_type})
 
+
 def _this_node():
-    '''
-    Return correct nodename for pacemaker for this node
-    :returns: nodename for this node
-    '''
     # Hostname. This is a shorterm point fix that will allow us to make HP2 release more
     # functional. Between el6 and el7 (truthfully we should probably be looking at Pacemaker or
     # Corosync versions) Pacemaker started to use fully qualified domain names rather than just the
@@ -736,13 +733,14 @@ def _get_target_config(uuid):
 
 
 def target_running(uuid):
+    # This is called by the Target RA from corosync
     from os import _exit
     try:
         info = _get_target_config(uuid)
-    except (KeyError, TypeError) as e:
+    except (KeyError, TypeError) as err:
         # it can't possibly be running here if the config entry for
         # it doesn't even exist, or if the store doesn't even exist!
-        console_log.warning("Exception getting target config: '%s'" % e)
+        console_log.warning("Exception getting target config: " + err)
         _exit(1)
 
     filesystem = FileSystem(info['backfstype'], info['bdev'])

--- a/chroma_agent/action_plugins/manage_targets.py
+++ b/chroma_agent/action_plugins/manage_targets.py
@@ -800,7 +800,7 @@ def convert_targets(force=False):
 
     this_node = _this_node()
 
-    # node elements are number from 1
+    # node elements are numbered from 1
     # dc-uuid is the node id of the domain controller
     dcuuid = next((node.getAttribute('uname') for node in dom.getElementsByTagName('node')
                    if node.getAttribute("id") == dom.documentElement.getAttribute('dc-uuid')), "")

--- a/chroma_agent/action_plugins/manage_targets.py
+++ b/chroma_agent/action_plugins/manage_targets.py
@@ -358,7 +358,8 @@ def configure_target_ha(primary, device, ha_label, uuid, mount_point):
 
         # Create Lustre resource and add target=uuid as an attribute
         result = AgentShell.run(['pcs', 'resource', 'create', ha_label, 'ocf:lustre:Lustre',
-                                 'target=%s' % realpath, 'mountpoint=%s' % mount_point] + group)
+                                 'target=%s' % realpath, 'mountpoint=%s' % mount_point,
+                                 '--disabled'] + group)
 
         score = 20
         preference = "primary"

--- a/chroma_agent/action_plugins/manage_targets.py
+++ b/chroma_agent/action_plugins/manage_targets.py
@@ -127,7 +127,9 @@ def get_resource_locations():
 
     if result.rc != 0:
         # Pacemaker not running, or no resources configured yet
-        return {"crm_mon_error": result}
+        return {"crm_mon_error": {"rc": result.rc,
+                                  "stdout": result.stdout,
+                                  "stderr": result.stderr}}
 
     dom = parseString(result.stdout)
 
@@ -794,7 +796,9 @@ def convert_targets(force=False):
 
     if result.rc != 0:
         # Pacemaker not running, or no resources configured yet
-        return {"crm_mon_error": result}
+        return {"crm_mon_error": {"rc": result.rc,
+                                  "stdout": result.stdout,
+                                  "stderr": result.stderr}}
 
     dom = parseString(result.stdout)
 

--- a/python-iml-agent.spec.in
+++ b/python-iml-agent.spec.in
@@ -156,9 +156,6 @@ systemctl preset %{unit_name} >/dev/null 2>&1
 # this will either convert an old (pre-4.1) config or initialize
 chroma-agent convert_agent_config
 
-%post -n python2-%{pypi_name}-management
-chroma-agent convert_targets
-
 %preun
 %systemd_preun %{unit_name}
 

--- a/python-iml-agent.spec.in
+++ b/python-iml-agent.spec.in
@@ -85,6 +85,7 @@ Requires:       ed
 
 Requires:       fence-agents
 Requires:       fence-agents-virsh
+Requires:	lustre-resource-agents
 
 %description -n python2-%{pypi_name}-management
 This package layers on management capabilities for Integrated Manager for Lustre Agent.
@@ -122,6 +123,7 @@ cat <<EndOfList>>management.files
 %{python_sitelib}/chroma_agent/action_plugins/manage_*.py*
 %{python_sitelib}/chroma_agent/templates/
 %{_usr}/lib/ocf/resource.d/chroma/Target
+%{_usr}/lib/ocf/resource.d/chroma/ZFS
 %{_sbindir}/fence_chroma
 %{_sbindir}/chroma-copytool-monitor
 EndOfList

--- a/python-iml-agent.spec.in
+++ b/python-iml-agent.spec.in
@@ -156,6 +156,9 @@ systemctl preset %{unit_name} >/dev/null 2>&1
 # this will either convert an old (pre-4.1) config or initialize
 chroma-agent convert_agent_config
 
+%post -n python2-%{pypi_name}-management
+chroma-agent convert_targets
+
 %preun
 %systemd_preun %{unit_name}
 

--- a/python-iml-agent.spec.in
+++ b/python-iml-agent.spec.in
@@ -123,6 +123,7 @@ cat <<EndOfList>>management.files
 %{python_sitelib}/chroma_agent/action_plugins/manage_*.py*
 %{python_sitelib}/chroma_agent/templates/
 %{_usr}/lib/ocf/resource.d/chroma/Target
+# ZFS is pulled from resource-agents master (see README.md)
 %{_usr}/lib/ocf/resource.d/chroma/ZFS
 %{_sbindir}/fence_chroma
 %{_sbindir}/chroma-copytool-monitor

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'Programming Language :: Python :: 2.7',
     ],
     keywords = 'IML lustre high-availability',
-    data_files=[('/usr/lib/ocf/resource.d/chroma', ['Target'])],
+    data_files=[('/usr/lib/ocf/resource.d/chroma', ['Target', 'ZFS'])],
     entry_points = {
         'console_scripts': [
             'chroma-agent = chroma_agent.cli:main',

--- a/tests/actions_plugins/test_manage_target.py
+++ b/tests/actions_plugins/test_manage_target.py
@@ -357,6 +357,57 @@ class TestFormatTarget(CommandCaptureTestCase):
     def test_unknown_opt(self):
         self.assertRaises(TypeError, self.manage_targets.format_target, unknown='whatever')
 
+class TestXMLParsing(unittest.TestCase):
+    xml_crm_mon = """<?xml version="1.0"?>
+<crm_mon version="1.1.18">
+    <summary>
+        <stack type="corosync" />
+        <current_dc present="true" version="1.1.18-11.el7_5.3-2b07d5c5a9" name="iml-mds01.iml" id="1" with_quorum="true" />
+        <last_update time="Tue Oct 23 16:09:16 2018" />
+        <last_change time="Sat Oct 20 13:34:12 2018" user="root" client="cibadmin" origin="iml-mds01.iml" />
+        <nodes_configured number="2" expected_votes="unknown" />
+        <resources_configured number="5" disabled="0" blocked="0" />
+        <cluster_options stonith-enabled="true" symmetric-cluster="true" no-quorum-policy="stop" maintenance-mode="false" />
+    </summary>
+    <nodes>
+        <node name="iml-mds01.iml" id="2" online="true" standby="false" standby_onfail="false" maintenance="false" pending="false" unclean="false" shutdown="false" expected_up="true" is_dc="false" resources_running="3" type="member" />
+        <node name="iml-mds02.iml" id="1" online="true" standby="false" standby_onfail="false" maintenance="false" pending="false" unclean="false" shutdown="false" expected_up="true" is_dc="false" resources_running="2" type="member" />
+    </nodes>
+    <resources>
+        <resource id="st-fencing" resource_agent="stonith:fence_chroma" role="Started" active="true" orphaned="false" blocked="false" managed="true" failed="false" failure_ignored="false" nodes_running_on="1" >
+            <node name="iml-mds01.iml" id="2" cached="false"/>
+        </resource>
+        <resource id="MGS_054510" resource_agent="ocf::lustre:Lustre" role="Started" active="true" orphaned="false" blocked="false" managed="true" failed="false" failure_ignored="false" nodes_running_on="1" >
+            <node name="iml-mds02.iml" id="1" cached="false"/>
+        </resource>
+        <group id="group-fs1-MDT0001_41549d" number_resources="2" >
+             <resource id="fs1-MDT0001_41549d-zfs" resource_agent="ocf::chroma:ZFS" role="Started" active="true" orphaned="false" blocked="false" managed="true" failed="false" failure_ignored="false" nodes_running_on="1" >
+                 <node name="iml-mds01.iml" id="2" cached="false"/>
+             </resource>
+             <resource id="fs1-MDT0001_41549d" resource_agent="ocf::lustre:Lustre" role="Started" active="true" orphaned="false" blocked="false" managed="true" failed="false" failure_ignored="false" nodes_running_on="1" >
+                 <node name="iml-mds01.iml" id="2" cached="false"/>
+             </resource>
+        </group>
+        <resource id="fs1-MDT0000_6cc06e" resource_agent="ocf::chroma:Target" role="Started" target_role="Started" active="true" orphaned="false" blocked="false" managed="true" failed="false" failure_ignored="false" nodes_running_on="1" >
+            <node name="iml-mds01.iml" id="1" cached="false"/>
+        </resource>
+   </resources>
+   <node_attributes>
+        <node name="iml-mds01.iml">
+        </node>
+        <node name="iml-mds02.iml">
+        </node>
+    </node_attributes>
+</crm_mon>
+    """
+
+    def test_get_resource_locations(self):
+        from chroma_agent.action_plugins import manage_targets
+        self.assertDictEqual(manage_targets._get_resource_locations(self.xml_crm_mon),
+                             {'fs1-MDT0000_6cc06e': 'iml-mds01.iml',
+                              'fs1-MDT0001_41549d': 'iml-mds01.iml',
+                              'MGS_054510': 'iml-mds02.iml'})
+        
 
 class TestCheckBlockDevice(CommandCaptureTestCase, AgentUnitTestCase):
     def setUp(self):

--- a/tests/actions_plugins/test_manage_target.py
+++ b/tests/actions_plugins/test_manage_target.py
@@ -358,28 +358,6 @@ class TestFormatTarget(CommandCaptureTestCase):
         self.assertRaises(TypeError, self.manage_targets.format_target, unknown='whatever')
 
 
-class TestXMLParsing(unittest.TestCase):
-    xml_example = """<primitive class="ocf" provider="chroma" type="Target" id="MGS_a3903a">
-  <meta_attributes id="MGS_a3903a-meta_attributes">
-    <nvpair name="target-role" id="MGS_a3903a-meta_attributes-target-role" value="Started"/>
-  </meta_attributes>
-  <operations id="MGS_a3903a-operations">
-    <op id="MGS_a3903a-monitor-120" interval="120" name="monitor" timeout="60"/>
-    <op id="MGS_a3903a-start-0" interval="0" name="start" timeout="300"/>
-    <op id="MGS_a3903a-stop-0" interval="0" name="stop" timeout="300"/>
-  </operations>
-  <instance_attributes id="MGS_a3903a-instance_attributes">
-    <nvpair id="MGS_a3903a-instance_attributes-target" name="target" value="c2890397-e0a2-4759-8f4e-df5ed64e1518"/>
-  </instance_attributes>
-</primitive>
-"""
-
-    def test_get_nvpairid_from_xml(self):
-        from chroma_agent.action_plugins import manage_targets
-        self.assertEqual('c2890397-e0a2-4759-8f4e-df5ed64e1518',
-                         manage_targets._get_nvpairid_from_xml(self.xml_example))
-
-
 class TestCheckBlockDevice(CommandCaptureTestCase, AgentUnitTestCase):
     def setUp(self):
         super(TestCheckBlockDevice, self).setUp()


### PR DESCRIPTION
This stops using the Target resource agent, and utilizes the ZFS and Lustre resources agents.
We supply the ZFS one, but it's a copy of the one that's been merged upstream resource-agents repo.
The Lustre resource agent comes from lustre-resource-agents.
This migrates away from writing XML into crm and uses pcs command line to control pacemaker.
