### PR TITLE
Skip NetworkManager update

### DIFF
--- a/chroma_agent/lib/yum_utils.py
+++ b/chroma_agent/lib/yum_utils.py
@@ -49,8 +49,7 @@ def yum_util(action,
     elif action == 'update':
         cmd = [
             'dnf', 'update', '--allowerasing', '-y', '--exclude',
-            'kernel-debug', '--exclude'
-            'NetworkManager*'
+            'kernel-debug', '--exclude', 'NetworkManager*'
         ] + repo_arg + list(packages)
     elif action == 'requires':
         cmd = ['dnf', 'repoquery', '--latest-limit', '1', '--requires'] + \

--- a/tests/actions_plugins/test_agent_updates.py
+++ b/tests/actions_plugins/test_agent_updates.py
@@ -47,46 +47,65 @@ sslclientcert = {2}
         with patch('os.rename', create=True) as mock_rename:
             with patch('os.open', create=True):
                 with patch('os.fdopen', spec=file, create=True) as mock_fsopen:
-                    with patch.object(chroma_agent.config, 'path', "/var/lib/chroma/", create=True):
-                        self.assertEqual(agent_updates.configure_repo('filename', provided_content), agent_result_ok)
-                        mock_fsopen.return_value.write.assert_called_once_with(expected_content)
-                        mock_rename.assert_called_once_with('/etc/yum.repos.d/filename.tmp', '/etc/yum.repos.d/filename')
+                    with patch.object(
+                            chroma_agent.config,
+                            'path',
+                            "/var/lib/chroma/",
+                            create=True):
+                        self.assertEqual(
+                            agent_updates.configure_repo(
+                                'filename', provided_content), agent_result_ok)
+                        mock_fsopen.return_value.write.assert_called_once_with(
+                            expected_content)
+                        mock_rename.assert_called_once_with(
+                            '/etc/yum.repos.d/filename.tmp',
+                            '/etc/yum.repos.d/filename')
 
     def test_unconfigure_repo(self):
-        self.assertEqual(agent_updates.unconfigure_repo(self.tmpRepo.name), agent_result_ok)
+        self.assertEqual(
+            agent_updates.unconfigure_repo(self.tmpRepo.name), agent_result_ok)
         self.assertFalse(os.path.exists(self.tmpRepo.name))
 
     def test_unconfigure_repo_no_file(self):
         os.remove(self.tmpRepo.name)
         self.assertFalse(os.path.exists(self.tmpRepo.name))
-        self.assertEqual(agent_updates.unconfigure_repo(self.tmpRepo.name), agent_result_ok)
+        self.assertEqual(
+            agent_updates.unconfigure_repo(self.tmpRepo.name), agent_result_ok)
 
     def test_kernel_status(self):
         def run(arg_list):
-            values = {("rpm", "-q", "--whatprovides", "kmod-lustre"):
-                      "kmod-lustre-1.2.3-1.el6.x86_64\n",
-                      ("uname", "-r"):
-                      "2.6.32-358.2.1.el6.x86_64\n",
-                      ("rpm", "-q", "kernel"):
-                      "kernel-2.6.32-358.2.1.el6.x86_64\n"
-                      "kernel-2.6.32-358.18.1.el6_lustre.x86_64\n"}
+            values = {
+                ("rpm", "-q", "--whatprovides", "kmod-lustre"):
+                "kmod-lustre-1.2.3-1.el6.x86_64\n",
+                ("uname", "-r"):
+                "2.6.32-358.2.1.el6.x86_64\n",
+                ("rpm", "-q", "kernel"):
+                "kernel-2.6.32-358.2.1.el6.x86_64\n"
+                "kernel-2.6.32-358.18.1.el6_lustre.x86_64\n"
+            }
             return Shell.RunResult(0, values[tuple(arg_list)], "", False)
 
         with patch('chroma_agent.lib.shell.AgentShell.run', side_effect=run):
             result = agent_updates.kernel_status()
-            self.assertDictEqual(result, {
-                'required': 'kernel-2.6.32-358.18.1.el6_lustre.x86_64',
-                'running': 'kernel-2.6.32-358.2.1.el6.x86_64',
-                'available': [
-                    "kernel-2.6.32-358.2.1.el6.x86_64",
-                    "kernel-2.6.32-358.18.1.el6_lustre.x86_64"
-                ]
-            })
+            self.assertDictEqual(
+                result, {
+                    'required':
+                    'kernel-2.6.32-358.18.1.el6_lustre.x86_64',
+                    'running':
+                    'kernel-2.6.32-358.2.1.el6.x86_64',
+                    'available': [
+                        "kernel-2.6.32-358.2.1.el6.x86_64",
+                        "kernel-2.6.32-358.18.1.el6_lustre.x86_64"
+                    ]
+                })
 
     def test_install_packages(self):
-        self.add_commands(CommandCaptureCommand(('dnf', 'clean', 'all', '--enablerepo=*')),
-                          CommandCaptureCommand(('dnf', 'repoquery', '--latest-limit', '1', '--requires', '--enablerepo=myrepo', 'foo', 'bar'),
-                                                stdout="""/usr/bin/python
+        self.add_commands(
+            CommandCaptureCommand(('dnf', 'clean', 'all', '--enablerepo=*')),
+            CommandCaptureCommand(
+                ('dnf', 'repoquery', '--latest-limit', '1', '--requires',
+                 '--enablerepo=myrepo', 'foo', 'bar'),
+                stdout="""/usr/bin/python
 python >= 2.4
 python(abi) = 2.6
 yum >= 3.2.29
@@ -94,28 +113,46 @@ yum >= 3.2.29
 kernel = 2.6.32-279.14.1.el6_lustre
 lustre-backend-fs
         """),
-                          CommandCaptureCommand(('dnf', 'install', '--allowerasing', '-y', '--exclude', 'kernel-debug', '--enablerepo=myrepo', 'foo', 'bar', 'kernel-2.6.32-279.14.1.el6_lustre')),
-                          CommandCaptureCommand(('dnf', 'repoquery', '--queryformat=%{name} %{version}-%{release}.%{arch} %{repoid}',
-                                                 '--upgrades', '--disablerepo=*', '--enablerepo=myrepo'), stdout="""
+            CommandCaptureCommand(
+                ('dnf', 'install', '--allowerasing', '-y', '--exclude',
+                 'kernel-debug', '--enablerepo=myrepo', 'foo', 'bar',
+                 'kernel-2.6.32-279.14.1.el6_lustre')),
+            CommandCaptureCommand(
+                ('dnf', 'repoquery',
+                 '--queryformat=%{name} %{version}-%{release}.%{arch} %{repoid}',
+                 '--upgrades', '--disablerepo=*', '--enablerepo=myrepo'),
+                stdout="""
 jasper-libs.x86_64                                                                             1.900.1-16.el6_6.3                                                                             myrepo
 """),
-                          CommandCaptureCommand(('dnf', 'update', '--allowerasing', '-y', '--exclude', 'kernel-debug', '--enablerepo=myrepo', 'jasper-libs.x86_64')),
-                          CommandCaptureCommand(('grubby', '--default-kernel'), stdout='/boot/vmlinuz-2.6.32-504.3.3.el6.x86_64'),
-                          CommandCaptureCommand(('systemctl', 'start', 'iml-update-check')),
-                          CommandCaptureCommand(('systemctl', 'is-active', 'iml-update-check')),
-                          )
+            CommandCaptureCommand(
+                ('dnf', 'update', '--allowerasing', '-y', '--exclude',
+                 'kernel-debug', '--exclude', 'NetworkManager*',
+                 '--enablerepo=myrepo', 'jasper-libs.x86_64')),
+            CommandCaptureCommand(
+                ('grubby', '--default-kernel'),
+                stdout='/boot/vmlinuz-2.6.32-504.3.3.el6.x86_64'),
+            CommandCaptureCommand(('systemctl', 'start', 'iml-update-check')),
+            CommandCaptureCommand(('systemctl', 'is-active',
+                                   'iml-update-check')),
+        )
 
         def isfile(arg):
             return True
 
         with patch('os.path.isfile', side_effect=isfile):
-            self.assertEqual(agent_updates.install_packages(['myrepo'], ['foo', 'bar']), agent_result_ok)
+            self.assertEqual(
+                agent_updates.install_packages(['myrepo'], ['foo', 'bar']),
+                agent_result_ok)
 
         self.assertRanAllCommandsInOrder()
 
     def test_install_packages_hyd_4050_grubby(self):
-        self.add_commands(CommandCaptureCommand(('dnf', 'clean', 'all', '--enablerepo=*')),
-                          CommandCaptureCommand(('dnf', 'repoquery', '--latest-limit', '1', '--requires', '--enablerepo=myrepo', 'foo'), stdout="""/usr/bin/python
+        self.add_commands(
+            CommandCaptureCommand(('dnf', 'clean', 'all', '--enablerepo=*')),
+            CommandCaptureCommand(
+                ('dnf', 'repoquery', '--latest-limit', '1', '--requires',
+                 '--enablerepo=myrepo', 'foo'),
+                stdout="""/usr/bin/python
 python >= 2.4
 python(abi) = 2.6
 yum >= 3.2.29
@@ -123,22 +160,32 @@ yum >= 3.2.29
 kernel = 2.6.32-279.14.1.el6_lustre
 lustre-backend-fs
         """),
-                          CommandCaptureCommand(('dnf', 'install', '--allowerasing', '-y', '--exclude', 'kernel-debug', '--enablerepo=myrepo', 'foo', 'kernel-2.6.32-279.14.1.el6_lustre')),
-                          CommandCaptureCommand(('dnf', 'repoquery', '--queryformat=%{name} %{version}-%{release}.%{arch} %{repoid}',
-                                                 '--upgrades', '--disablerepo=*', '--enablerepo=myrepo')),
-                          CommandCaptureCommand(('grubby', '--default-kernel'), rc=1))
+            CommandCaptureCommand(
+                ('dnf', 'install', '--allowerasing', '-y', '--exclude',
+                 'kernel-debug', '--enablerepo=myrepo', 'foo',
+                 'kernel-2.6.32-279.14.1.el6_lustre')),
+            CommandCaptureCommand((
+                'dnf', 'repoquery',
+                '--queryformat=%{name} %{version}-%{release}.%{arch} %{repoid}',
+                '--upgrades', '--disablerepo=*', '--enablerepo=myrepo')),
+            CommandCaptureCommand(('grubby', '--default-kernel'), rc=1))
 
         def isfile(arg):
             return True
 
         with patch('os.path.isfile', side_effect=isfile):
-            self.assertTrue('error' in agent_updates.install_packages(['myrepo'], ['foo']))
+            self.assertTrue(
+                'error' in agent_updates.install_packages(['myrepo'], ['foo']))
 
         self.assertRanAllCommandsInOrder()
 
     def test_install_packages_4050_initramfs(self):
-        self.add_commands(CommandCaptureCommand(('dnf', 'clean', 'all', '--enablerepo=*')),
-                          CommandCaptureCommand(('dnf', 'repoquery', '--latest-limit', '1', '--requires', '--enablerepo=myrepo', 'foo'), stdout="""/usr/bin/python
+        self.add_commands(
+            CommandCaptureCommand(('dnf', 'clean', 'all', '--enablerepo=*')),
+            CommandCaptureCommand(
+                ('dnf', 'repoquery', '--latest-limit', '1', '--requires',
+                 '--enablerepo=myrepo', 'foo'),
+                stdout="""/usr/bin/python
 python >= 2.4
 python(abi) = 2.6
 yum >= 3.2.29
@@ -146,16 +193,24 @@ yum >= 3.2.29
 kernel = 2.6.32-279.14.1.el6_lustre
 lustre-backend-fs
         """),
-                          CommandCaptureCommand(('dnf', 'install', '--allowerasing', '-y', '--exclude', 'kernel-debug', '--enablerepo=myrepo', 'foo', 'kernel-2.6.32-279.14.1.el6_lustre')),
-                          CommandCaptureCommand(('dnf', 'repoquery', '--queryformat=%{name} %{version}-%{release}.%{arch} %{repoid}',
-                                                 '--upgrades', '--disablerepo=*', '--enablerepo=myrepo')),
-                          CommandCaptureCommand(('grubby', '--default-kernel'), stdout='/boot/vmlinuz-2.6.32-504.3.3.el6.x86_64'))
+            CommandCaptureCommand(
+                ('dnf', 'install', '--allowerasing', '-y', '--exclude',
+                 'kernel-debug', '--enablerepo=myrepo', 'foo',
+                 'kernel-2.6.32-279.14.1.el6_lustre')),
+            CommandCaptureCommand((
+                'dnf', 'repoquery',
+                '--queryformat=%{name} %{version}-%{release}.%{arch} %{repoid}',
+                '--upgrades', '--disablerepo=*', '--enablerepo=myrepo')),
+            CommandCaptureCommand(
+                ('grubby', '--default-kernel'),
+                stdout='/boot/vmlinuz-2.6.32-504.3.3.el6.x86_64'))
 
         def isfile(arg):
             return False
 
         with patch('os.path.isfile', side_effect=isfile):
-            self.assertTrue('error' in agent_updates.install_packages(['myrepo'], ['foo']))
+            self.assertTrue(
+                'error' in agent_updates.install_packages(['myrepo'], ['foo']))
 
         self.assertRanAllCommandsInOrder()
 
@@ -163,32 +218,66 @@ lustre-backend-fs
         config.update('settings', 'profile', {'managed': False})
 
         # Go from managed = False to managed = True
-        self.add_command(('dnf', 'install', '--allowerasing', '-y', '--exclude', 'kernel-debug', 'python2-iml-agent-management'))
-        self.assertEqual(agent_updates.update_profile({'managed': True}), agent_result_ok)
+        self.add_command(
+            ('dnf', 'install', '--allowerasing', '-y', '--exclude',
+             'kernel-debug', 'python2-iml-agent-management'))
+        self.assertEqual(
+            agent_updates.update_profile({
+                'managed': True
+            }), agent_result_ok)
         self.assertRanAllCommandsInOrder()
 
         # Go from managed = True to managed = False
         self.reset_command_capture()
-        self.add_command(('dnf', 'remove', '-y', 'python2-iml-agent-management'))
-        self.assertEqual(agent_updates.update_profile({'managed': False}), agent_result_ok)
+        self.add_command(('dnf', 'remove', '-y',
+                          'python2-iml-agent-management'))
+        self.assertEqual(
+            agent_updates.update_profile({
+                'managed': False
+            }), agent_result_ok)
         self.assertRanAllCommandsInOrder()
 
         # Go from managed = False to managed = False
         self.reset_command_capture()
-        self.assertEqual(agent_updates.update_profile({'managed': False}), agent_result_ok)
+        self.assertEqual(
+            agent_updates.update_profile({
+                'managed': False
+            }), agent_result_ok)
         self.assertRanAllCommandsInOrder()
 
     def test_set_profile_fail(self):
         # Three times because yum will try three times.
-        self.add_commands(CommandCaptureCommand(('dnf', 'install', '--allowerasing', '-y', '--exclude', 'kernel-debug', 'python2-iml-agent-management'), rc=1, stdout="Bad command stdout", stderr="Bad command stderr"),
-                          CommandCaptureCommand(('dnf', 'clean', 'metadata')),
-                          CommandCaptureCommand(('dnf', 'install', '--allowerasing', '-y', '--exclude', 'kernel-debug', 'python2-iml-agent-management'), rc=1, stdout="Bad command stdout", stderr="Bad command stderr"),
-                          CommandCaptureCommand(('dnf', 'clean', 'metadata')),
-                          CommandCaptureCommand(('dnf', 'install', '--allowerasing', '-y', '--exclude', 'kernel-debug', 'python2-iml-agent-management'), rc=1, stdout="Bad command stdout", stderr="Bad command stderr"),
-                          CommandCaptureCommand(('dnf', 'clean', 'metadata')))
+        self.add_commands(
+            CommandCaptureCommand(
+                ('dnf', 'install', '--allowerasing', '-y', '--exclude',
+                 'kernel-debug', 'python2-iml-agent-management'),
+                rc=1,
+                stdout="Bad command stdout",
+                stderr="Bad command stderr"),
+            CommandCaptureCommand(('dnf', 'clean', 'metadata')),
+            CommandCaptureCommand(
+                ('dnf', 'install', '--allowerasing', '-y', '--exclude',
+                 'kernel-debug', 'python2-iml-agent-management'),
+                rc=1,
+                stdout="Bad command stdout",
+                stderr="Bad command stderr"),
+            CommandCaptureCommand(('dnf', 'clean', 'metadata')),
+            CommandCaptureCommand(
+                ('dnf', 'install', '--allowerasing', '-y', '--exclude',
+                 'kernel-debug', 'python2-iml-agent-management'),
+                rc=1,
+                stdout="Bad command stdout",
+                stderr="Bad command stderr"),
+            CommandCaptureCommand(('dnf', 'clean', 'metadata')))
 
         config.update('settings', 'profile', {'managed': False})
 
         # Go from managed = False to managed = True, but it will fail.
-        self.assertEqual(agent_updates.update_profile({'managed': True}), agent_error('Unable to set profile because yum returned Bad command stdout'))
+        self.assertEqual(
+            agent_updates.update_profile({
+                'managed': True
+            }),
+            agent_error(
+                'Unable to set profile because yum returned Bad command stdout'
+            ))
         self.assertRanAllCommandsInOrder()


### PR DESCRIPTION
Skip any NetworkManager* rpms when updating
rpms on agent nodes.

This should work around an issue where updating NetworkManager causes
the agent connection to drop.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>