### PR TITLE
Lustre ra fixes

### DIFF
--- a/chroma_agent/action_plugins/manage_targets.py
+++ b/chroma_agent/action_plugins/manage_targets.py
@@ -369,19 +369,9 @@ def _configure_target_ha(ha_label, info, enabled=False):
             console_log.error("Resource (%s) create failed:%d: %s", zpool, result.rc, result.stderr)
             return result
 
-        realpath = info['bdev']
-
-    else:
-        # Because of LU-11461 find realpath of devices and use that as Lustre target
-        result = AgentShell.run(['realpath', info['bdev']])
-        if result.rc == 0:
-            realpath = result.stdout.strip()
-        else:
-            realpath = info['bdev']
-
     # Create Lustre resource and add target=uuid as an attribute
     result = AgentShell.run(['pcs', 'resource', 'create', ha_label, 'ocf:lustre:Lustre',
-                             'target={}'.format(realpath),
+                             'target={}'.format(info['bdev']),
                              'mountpoint={}'.format(info['mntpt'])] + extra)
 
     if result.rc != 0:


### PR DESCRIPTION
This fixes ZFS resources not coming online after being stopped via disable group.

This also prevents realpath of bdev from being used to define resources.  This is now safe across reboots.  realpath of disk/by-id not matching findmnt of scsi devices will be fixed in lustre RA see [LU-11461](https://jira.whamcloud.com/browse/LU-11461).