### PR TITLE
Wait for ZFS resource to start before creating Lustre resource.

### DIFF
--- a/tests/actions_plugins/test_manage_target.py
+++ b/tests/actions_plugins/test_manage_target.py
@@ -405,6 +405,7 @@ class TestXMLParsing(unittest.TestCase):
         from chroma_agent.action_plugins import manage_targets
         self.assertDictEqual(manage_targets._get_resource_locations(self.xml_crm_mon),
                              {'fs1-MDT0000_6cc06e': 'iml-mds01.iml',
+                              'fs1-MDT0001_41549d-zfs', 'iml-mds01.iml',
                               'fs1-MDT0001_41549d': 'iml-mds01.iml',
                               'MGS_054510': 'iml-mds02.iml'})
         

--- a/tests/actions_plugins/test_manage_target.py
+++ b/tests/actions_plugins/test_manage_target.py
@@ -405,7 +405,7 @@ class TestXMLParsing(unittest.TestCase):
         from chroma_agent.action_plugins import manage_targets
         self.assertDictEqual(manage_targets._get_resource_locations(self.xml_crm_mon),
                              {'fs1-MDT0000_6cc06e': 'iml-mds01.iml',
-                              'fs1-MDT0001_41549d-zfs', 'iml-mds01.iml',
+                              'fs1-MDT0001_41549d-zfs': 'iml-mds01.iml',
                               'fs1-MDT0001_41549d': 'iml-mds01.iml',
                               'MGS_054510': 'iml-mds02.iml'})
         


### PR DESCRIPTION
Move wait into _configure_target_ha if enabled is True.

Signed-off-by: Nathaniel Clark <nclark@whamcloud.com>