### PR TITLE
Format Repo with black

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,57 +1,63 @@
 language: python
-python: '2.7'
+python: "2.7"
 sudo: required
 services:
-  - docker
+    - docker
 addons:
-  apt:
-    packages:
-    - libpcap0.8-dev
+    apt:
+        packages:
+            - libpcap0.8-dev
 jobs:
-  include:
-  - stage: test
-    env: Type='module test'
-    script:
-    - nosetests
-  - stage: test
-    env: Type='mock build test'
-    script:
-    - ./include/travis/run_in_centos7_docker.sh include/travis/mock_build_test.sh
-  - stage: cd
-    git:
-      depth: 999999
-    env: Type='Continuous Deployment'
-    script:
-      - include/travis/copr-deploy.sh prepare
-      - ./travis_wait "./include/travis/run_in_centos7_docker.sh include/travis/copr-deploy.sh build_srpm"
-  - stage: deploy-pypi
-    env: Type='PyPi deploy'
-    script: skip
-    deploy:
-      provider: pypi
-      user: iml
-      password:
-        secure: QznryPOPomArAOyHl0qTC8JBR7qAmp81SAD6jnUwYzd1JO5lk7nIw25PMA2sU24uaTSEKp37Dx+qLeYIECz/HATFP0FlXDwgfDHgLinasz0+xaKlbhzhuWkAQwHe3Jc8pjdl7npm1Kh1xJU0Rsiwm2bnhfqGT3czsvOZoVoRdOKB0oW8sex6u3evXOa9NoFLX8WUkUIEUntT3HgOrxygY9pPAyu8qo0wluL4YRDY8nYaaeTOX8hPfa883ctYiMiiGxyvqGnfE264h4JlX7OYoBr5rF0ZS0wcqekLjnLLQwh+sEsdP9PNIlh+I4Hfkku6errhbD96w2YW6WySGcngiRSal7cHOa/lOAWm74M3nMoFLl7zFuX5BkVwSoRcyjibJogXyiladEs20eVmLcKcAHfj1OA//pQwvbNow3xcUci1mjmgV/v7VmfK1bPo9cziK6SNE1k96FI92BlqpuxrhQEy+hprq/SOGB8QJ6jo5/lvXwPFrsn4DHxUlGQPFk1hCo7TPRq+a//uVRuLmz4eXvDVrEoB+MR4oo9ltPpnXI7ylVnmavGR/vgw7y23tTucGkPHlFK9ubqv2cydTqxyJfkF00iDlr1ZNWjt1LUBWCdlgyor9AM4KqiVamc3jDaHj4z//l65JNEwxPOJ18tmCX5n29cY3ibLLO5kfFkVVVI=
-      on:
-        all_branches: true
-        distributions: sdist bdist_wheel
-    skip_upload_docs: true
-  - stage: deploy-copr
-    env: Type='Copr deploy'
-    script: skip
-    before_deploy:
-    - include/travis/copr-deploy.sh prepare
-    deploy:
-      skip_cleanup: true
-      provider: script
-      script: ./travis_wait "./include/travis/run_in_centos7_docker.sh include/travis/copr-deploy.sh build"
-      on:
-        all_branches: true
+    include:
+        - stage: test
+          name: "module test"
+          script:
+              - nosetests
+        - stage: test
+          name: "mock build test"
+          script:
+              - ./include/travis/run_in_centos7_docker.sh include/travis/mock_build_test.sh
+        - stage: test
+          name: "Format Check"
+          python: "3.7"
+          script:
+              - pip install black
+              - black --check ./
+        - stage: cd
+          git:
+              depth: 999999
+          name: "Continuous Deployment"
+          script:
+              - include/travis/copr-deploy.sh prepare
+              - ./travis_wait "./include/travis/run_in_centos7_docker.sh include/travis/copr-deploy.sh build_srpm"
+        - stage: deploy-pypi
+          name: "PyPi deploy"
+          script: skip
+          deploy:
+              provider: pypi
+              user: iml
+              password:
+                  secure: QznryPOPomArAOyHl0qTC8JBR7qAmp81SAD6jnUwYzd1JO5lk7nIw25PMA2sU24uaTSEKp37Dx+qLeYIECz/HATFP0FlXDwgfDHgLinasz0+xaKlbhzhuWkAQwHe3Jc8pjdl7npm1Kh1xJU0Rsiwm2bnhfqGT3czsvOZoVoRdOKB0oW8sex6u3evXOa9NoFLX8WUkUIEUntT3HgOrxygY9pPAyu8qo0wluL4YRDY8nYaaeTOX8hPfa883ctYiMiiGxyvqGnfE264h4JlX7OYoBr5rF0ZS0wcqekLjnLLQwh+sEsdP9PNIlh+I4Hfkku6errhbD96w2YW6WySGcngiRSal7cHOa/lOAWm74M3nMoFLl7zFuX5BkVwSoRcyjibJogXyiladEs20eVmLcKcAHfj1OA//pQwvbNow3xcUci1mjmgV/v7VmfK1bPo9cziK6SNE1k96FI92BlqpuxrhQEy+hprq/SOGB8QJ6jo5/lvXwPFrsn4DHxUlGQPFk1hCo7TPRq+a//uVRuLmz4eXvDVrEoB+MR4oo9ltPpnXI7ylVnmavGR/vgw7y23tTucGkPHlFK9ubqv2cydTqxyJfkF00iDlr1ZNWjt1LUBWCdlgyor9AM4KqiVamc3jDaHj4z//l65JNEwxPOJ18tmCX5n29cY3ibLLO5kfFkVVVI=
+              on:
+                  all_branches: true
+                  distributions: sdist bdist_wheel
+          skip_upload_docs: true
+        - stage: deploy-copr
+          name: "Copr deploy"
+          script: skip
+          before_deploy:
+              - include/travis/copr-deploy.sh prepare
+          deploy:
+              skip_cleanup: true
+              provider: script
+              script: ./travis_wait "./include/travis/run_in_centos7_docker.sh include/travis/copr-deploy.sh build"
+              on:
+                  all_branches: true
 stages:
-  - test
-  - name: cd
-    if: branch = master AND type = push AND fork = false
-  - name: deploy-pypi
-    if: branch =~ ^v\d+\.\d+\.\d+$
-  - name: deploy-copr
-    if: branch =~ ^v\d+\.\d+\.\d+$
+    - test
+    - name: cd
+      if: branch = master AND type = push AND fork = false
+    - name: deploy-pypi
+      if: branch =~ ^v\d+\.\d+\.\d+$
+    - name: deploy-copr
+      if: branch =~ ^v\d+\.\d+\.\d+$

--- a/chroma_agent/__init__.py
+++ b/chroma_agent/__init__.py
@@ -7,14 +7,15 @@ import errno
 import os
 
 DEFAULT_AGENT_CONFIG = {
-    'lustre_client_root': "/mnt/lustre_clients",
-    'copytool_fifo_directory': "/var/spool",
-    'copytool_template': "--quiet --update-interval %(report_interval)s --event-fifo %(event_fifo)s --archive %(archive_number)s %(hsm_arguments)s %(mountpoint)s"
+    "lustre_client_root": "/mnt/lustre_clients",
+    "copytool_fifo_directory": "/var/spool",
+    "copytool_template": "--quiet --update-interval %(report_interval)s --event-fifo %(event_fifo)s --archive %(archive_number)s %(hsm_arguments)s %(mountpoint)s",
 }
 
 PRODUCTION_CONFIG_STORE = "/var/lib/chroma"
 DEVEL_CONFIG_STORE = os.path.join(os.path.dirname(__file__), ".dev_config_store")
 from config_store import ConfigStore
+
 try:
     config = ConfigStore(PRODUCTION_CONFIG_STORE)
 except OSError as e:
@@ -25,6 +26,7 @@ except OSError as e:
 
 try:
     from scm_version import VERSION, PACKAGE_VERSION, IS_RELEASE, BUILD
+
     __version__ = VERSION
     __package_version__ = PACKAGE_VERSION
     __build__ = BUILD
@@ -32,7 +34,7 @@ try:
 except ImportError:
     from pkginfo import UnpackedSDist
 
-    pkg = UnpackedSDist('.')
+    pkg = UnpackedSDist(".")
     __version__ = pkg.version
     __package_version__ = __version__
     __build__ = 1

--- a/chroma_agent/action_plugins/agent_setup.py
+++ b/chroma_agent/action_plugins/agent_setup.py
@@ -21,7 +21,7 @@ from chroma_agent.plugin_manager import ActionPluginManager, DevicePluginManager
 from iml_common.lib.service_control import ServiceControl
 from iml_common.lib.agent_rpc import agent_ok_or_error
 
-agent_service = ServiceControl.create('chroma-agent')
+agent_service = ServiceControl.create("chroma-agent")
 
 
 def _service_is_running():
@@ -35,17 +35,18 @@ def deregister_server():
     def disable_and_kill():
         console_log.info("Terminating")
 
-        storage_server_target = ServiceControl.create('iml-storage-server.target')
+        storage_server_target = ServiceControl.create("iml-storage-server.target")
         storage_server_target.disable()
         storage_server_target.stop()
-
 
     raise CallbackAfterResponse(None, disable_and_kill)
 
 
 def register_server(url, ca, secret, address=None):
     if _service_is_running() is True:
-        console_log.warning("chroma-agent service was running before registration, stopping.")
+        console_log.warning(
+            "chroma-agent service was running before registration, stopping."
+        )
         agent_service.stop()
 
     crypto = Crypto(conf.ENV_PATH)
@@ -53,14 +54,16 @@ def register_server(url, ca, secret, address=None):
     crypto.delete()
     crypto.install_authority(ca)
 
-    agent_client = AgentClient(url + "register/%s/" % secret,
-                               ActionPluginManager(),
-                               DevicePluginManager(),
-                               ServerProperties(),
-                               crypto)
+    agent_client = AgentClient(
+        url + "register/%s/" % secret,
+        ActionPluginManager(),
+        DevicePluginManager(),
+        ServerProperties(),
+        crypto,
+    )
 
     registration_result = agent_client.register(address)
-    crypto.install_certificate(registration_result['certificate'])
+    crypto.install_certificate(registration_result["certificate"])
 
     conf.set_server_url(url)
 
@@ -76,19 +79,28 @@ def register_server(url, ca, secret, address=None):
 def reregister_server(url, address):
     """ Update manager url and register agent address with manager """
     if _service_is_running() is True:
-        console_log.warning("chroma-agent service was running before registration, stopping.")
+        console_log.warning(
+            "chroma-agent service was running before registration, stopping."
+        )
         agent_service.stop()
 
     conf.set_server_url(url)
     crypto = Crypto(conf.ENV_PATH)
-    agent_client = AgentClient(url + 'reregister/', ActionPluginManager(), DevicePluginManager(), ServerProperties(),
-                               crypto)
-    data = {'address': address, 'fqdn': agent_client._fqdn}
+    agent_client = AgentClient(
+        url + "reregister/",
+        ActionPluginManager(),
+        DevicePluginManager(),
+        ServerProperties(),
+        crypto,
+    )
+    data = {"address": address, "fqdn": agent_client._fqdn}
 
     try:
         result = agent_client.post(data)
     except HttpError:
-        console_log.error("Reregistration failed to %s with request %s" % (agent_client.url, data))
+        console_log.error(
+            "Reregistration failed to %s with request %s" % (agent_client.url, data)
+        )
         raise
 
     console_log.info("Starting chroma-agent service")
@@ -101,6 +113,7 @@ def test():
     """A dummy action used for testing that the agent is available
     and successfully running actions."""
     pass
+
 
 ACTIONS = [deregister_server, register_server, reregister_server, test]
 CAPABILITIES = []

--- a/chroma_agent/action_plugins/agent_updates.py
+++ b/chroma_agent/action_plugins/agent_updates.py
@@ -17,21 +17,22 @@ from chroma_agent.lib.yum_utils import yum_util
 from iml_common.lib.agent_rpc import agent_result, agent_error, agent_result_ok
 from iml_common.lib.service_control import ServiceControl
 
-REPO_PATH = '/etc/yum.repos.d'
+REPO_PATH = "/etc/yum.repos.d"
 
 
 def configure_repo(filename, file_contents):
     crypto = Crypto(ENV_PATH)
     full_filename = os.path.join(REPO_PATH, filename)
-    temp_full_filename = full_filename + '.tmp'
+    temp_full_filename = full_filename + ".tmp"
 
-    file_contents = file_contents.format(crypto.AUTHORITY_FILE,
-                                         crypto.PRIVATE_KEY_FILE,
-                                         crypto.CERTIFICATE_FILE)
+    file_contents = file_contents.format(
+        crypto.AUTHORITY_FILE, crypto.PRIVATE_KEY_FILE, crypto.CERTIFICATE_FILE
+    )
 
     try:
         file_handle = os.fdopen(
-            os.open(temp_full_filename, os.O_WRONLY | os.O_CREAT, 0644), 'w')
+            os.open(temp_full_filename, os.O_WRONLY | os.O_CREAT, 0o644), "w"
+        )
         file_handle.write(file_contents)
         file_handle.close()
         os.rename(temp_full_filename, full_filename)
@@ -54,13 +55,13 @@ def unconfigure_repo(filename):
 
 
 def update_profile(profile):
-    '''
+    """
     Sets the profile to the profile_name by fetching the profile from the manager
     :param profile_name:
     :return: error or result OK
-    '''
-    old_profile = config.get('settings', 'profile')
-    '''
+    """
+    old_profile = config.get("settings", "profile")
+    """
     This is an incomplete solution but the incompleteness is at the bottom of the stack and we need this as a fix up
     for 2.2 release.
 
@@ -73,21 +74,22 @@ def update_profile(profile):
 
     This code might want to use the update_pacakges as well but it's not clear and we are in a pickle here. This code is
     not bad and doesn't have bad knock on effects.
-    '''
+    """
 
-    if old_profile['managed'] != profile['managed']:
-        if profile['managed']:
-            action = 'install'
+    if old_profile["managed"] != profile["managed"]:
+        if profile["managed"]:
+            action = "install"
         else:
-            action = 'remove'
+            action = "remove"
 
         try:
-            yum_util(action, packages=['python2-iml-agent-management'])
+            yum_util(action, packages=["python2-iml-agent-management"])
         except AgentShell.CommandExecutionError as cee:
-            return agent_error("Unable to set profile because yum returned %s"
-                               % cee.result.stdout)
+            return agent_error(
+                "Unable to set profile because yum returned %s" % cee.result.stdout
+            )
 
-    config.update('settings', 'profile', profile)
+    config.update("settings", "profile", profile)
 
     return agent_result_ok
 
@@ -103,52 +105,55 @@ def install_packages(repos, packages):
     :return: package report of the format given by the lustre device plugin
     """
     if packages != []:
-        yum_util('clean')
+        yum_util("clean")
 
-        out = yum_util('requires', enablerepo=repos, packages=packages)
+        out = yum_util("requires", enablerepo=repos, packages=packages)
         for requirement in [l.strip() for l in out.strip().split("\n")]:
             match = re.match("([^\)/]*) = (.*)", requirement)
             if match:
                 require_package, require_version = match.groups()
                 packages.append("%s-%s" % (require_package, require_version))
 
-        yum_util('install', enablerepo=repos, packages=packages)
+        yum_util("install", enablerepo=repos, packages=packages)
 
         error = _check_HYD4050()
 
         if error:
             return agent_error(error)
 
-    ServiceControl.create('iml-update-check').start(0)
+    ServiceControl.create("iml-update-check").start(0)
 
     return agent_result_ok
 
 
 def _check_HYD4050():
-    '''
+    """
     HYD-4050 means that kernels are not installed with a default kernel or the initramfs isn't present.
 
     This function checks for these cases and returns an error message if a problem exists.
 
     return: None if everything is OK, error message if not.
-    '''
+    """
 
     #  Make sure that there is an initramfs for the booting kernel
     try:
-        default_kernel = AgentShell.try_run(["grubby",
-                                             "--default-kernel"]).strip()
+        default_kernel = AgentShell.try_run(["grubby", "--default-kernel"]).strip()
     except AgentShell.CommandExecutionError:
-        return ("Unable to determine your default kernel.  "
-                "This node may not boot successfully until grub "
-                "is fixed to have a default kernel to boot.")
+        return (
+            "Unable to determine your default kernel.  "
+            "This node may not boot successfully until grub "
+            "is fixed to have a default kernel to boot."
+        )
 
-    default_kernel_version = default_kernel[default_kernel.find("-") + 1:]
+    default_kernel_version = default_kernel[default_kernel.find("-") + 1 :]
     initramfs = "/boot/initramfs-%s.img" % default_kernel_version
 
     if not os.path.isfile(initramfs):
-        return ("There is no initramfs (%s) for the default kernel (%s).  "
-                "This node may not boot successfully until an initramfs "
-                "is created." % (initramfs, default_kernel_version))
+        return (
+            "There is no initramfs (%s) for the default kernel (%s).  "
+            "This node may not boot successfully until an initramfs "
+            "is created." % (initramfs, default_kernel_version)
+        )
 
     return None
 
@@ -163,39 +168,44 @@ def kernel_status():
         # on a server, a required kernel is a lustre patched kernel since we
         # are building storage servers that can support both ldiskfs and zfs
         try:
-            required_kernel = \
-                next(k for k in sorted(AgentShell.try_run(["rpm", "-q",
-                                                           "kernel"]).split('\n'),
-                                       reverse=True)
-                     if "_lustre" in k)
+            required_kernel = next(
+                k
+                for k in sorted(
+                    AgentShell.try_run(["rpm", "-q", "kernel"]).split("\n"),
+                    reverse=True,
+                )
+                if "_lustre" in k
+            )
         except (AgentShell.CommandExecutionError, StopIteration):
             required_kernel = None
     elif AgentShell.run(["rpm", "-q", "kmod-lustre-client"]).rc == 0:
         # but on a worker, we can ask kmod-lustre-client what the required
         # kernel is
         try:
-            required_kernel_prefix = \
-                next(k for k in AgentShell.try_run(["rpm", "-q", "--requires",
-                                                    "kmod-lustre-client"]).split('\n')
-                     if "kernel >=" in k).split(" >= ")[1]
+            required_kernel_prefix = next(
+                k
+                for k in AgentShell.try_run(
+                    ["rpm", "-q", "--requires", "kmod-lustre-client"]
+                ).split("\n")
+                if "kernel >=" in k
+            ).split(" >= ")[1]
             required_kernel = AgentShell.try_run(
-                ["rpm", "-q",
-                 "kernel-%s*" % required_kernel_prefix]).split('\n')[0]
+                ["rpm", "-q", "kernel-%s*" % required_kernel_prefix]
+            ).split("\n")[0]
         except (AgentShell.CommandExecutionError, StopIteration):
             required_kernel = None
     else:
         required_kernel = None
 
     available_kernels = []
-    for installed_kernel in AgentShell.try_run(["rpm", "-q",
-                                                "kernel"]).split("\n"):
+    for installed_kernel in AgentShell.try_run(["rpm", "-q", "kernel"]).split("\n"):
         if installed_kernel:
             available_kernels.append(installed_kernel)
 
     return {
-        'running': running_kernel,
-        'required': required_kernel,
-        'available': available_kernels
+        "running": running_kernel,
+        "required": required_kernel,
+        "available": available_kernels,
     }
 
 
@@ -204,13 +214,17 @@ def restart_agent():
         daemon_log.info("Restarting iml-storage-server.target")
         # Use subprocess.Popen instead of try_run because we don't want to
         # wait for completion.
-        subprocess.Popen(['systemctl', 'restart', 'iml-storage-server.target'])
+        subprocess.Popen(["systemctl", "restart", "iml-storage-server.target"])
 
     raise CallbackAfterResponse(None, _shutdown)
 
 
 ACTIONS = [
-    configure_repo, unconfigure_repo, install_packages, kernel_status,
-    restart_agent, update_profile
+    configure_repo,
+    unconfigure_repo,
+    install_packages,
+    kernel_status,
+    restart_agent,
+    update_profile,
 ]
-CAPABILITIES = ['manage_updates']
+CAPABILITIES = ["manage_updates"]

--- a/chroma_agent/action_plugins/device_plugin.py
+++ b/chroma_agent/action_plugins/device_plugin.py
@@ -13,7 +13,7 @@ from iml_common.lib.agent_rpc import agent_error, agent_result_ok
 from iml_common.blockdevices.blockdevice import BlockDevice
 
 
-def device_plugin(plugin = None):
+def device_plugin(plugin=None):
     """
     Invoke a device plugin once to obtain a snapshot of what it
     is monitoring
@@ -51,7 +51,9 @@ def trigger_plugin_update(agent_daemon_context, plugin_names):
         plugin_names = agent_daemon_context.plugin_sessions.keys()
 
     for plugin_name in plugin_names:
-        agent_daemon_context.plugin_sessions[plugin_name]._plugin.trigger_plugin_update = True
+        agent_daemon_context.plugin_sessions[
+            plugin_name
+        ]._plugin.trigger_plugin_update = True
 
 
 @agent_daemon_startup_function()
@@ -86,5 +88,10 @@ def terminate_block_device_drivers():
     return agent_result_ok
 
 
-ACTIONS = [device_plugin, trigger_plugin_update, initialise_block_device_drivers, terminate_block_device_drivers]
+ACTIONS = [
+    device_plugin,
+    trigger_plugin_update,
+    initialise_block_device_drivers,
+    terminate_block_device_drivers,
+]
 CAPABILITIES = []

--- a/chroma_agent/action_plugins/manage_client_mounts.py
+++ b/chroma_agent/action_plugins/manage_client_mounts.py
@@ -42,13 +42,13 @@ def create_fstab_entry(mountspec, mountpoint):
 
 def mount_lustre_filesystem(mountspec, mountpoint):
     try:
-        os.makedirs(mountpoint, 0755)
+        os.makedirs(mountpoint, 0o755)
     except OSError as e:
         if e.errno != errno.EEXIST:
             raise
 
     create_fstab_entry(mountspec, mountpoint)
-    AgentShell.try_run(['/bin/mount', mountpoint])
+    AgentShell.try_run(["/bin/mount", mountpoint])
 
 
 def mount_lustre_filesystems(filesystems):
@@ -58,7 +58,7 @@ def mount_lustre_filesystems(filesystems):
 
 def unmount_lustre_filesystem(mountspec, mountpoint):
     delete_fstab_entry(mountspec, mountpoint)
-    AgentShell.try_run(['/bin/umount', mountpoint])
+    AgentShell.try_run(["/bin/umount", mountpoint])
 
 
 def unmount_lustre_filesystems(filesystems):
@@ -66,5 +66,10 @@ def unmount_lustre_filesystems(filesystems):
         unmount_lustre_filesystem(mountspec, mountpoint)
 
 
-ACTIONS = [mount_lustre_filesystems, unmount_lustre_filesystems, mount_lustre_filesystem, unmount_lustre_filesystem]
-CAPABILITIES = ['manage_client_mounts']
+ACTIONS = [
+    mount_lustre_filesystems,
+    unmount_lustre_filesystems,
+    mount_lustre_filesystem,
+    unmount_lustre_filesystem,
+]
+CAPABILITIES = ["manage_client_mounts"]

--- a/chroma_agent/action_plugins/manage_conf_params.py
+++ b/chroma_agent/action_plugins/manage_conf_params.py
@@ -6,11 +6,12 @@
 from chroma_agent.lib.shell import AgentShell
 
 
-def set_conf_param(key = None, value = None):
+def set_conf_param(key=None, value=None):
     if value is not None:
-        AgentShell.try_run(['lctl', 'conf_param', "%s=%s" % (key, value)])
+        AgentShell.try_run(["lctl", "conf_param", "%s=%s" % (key, value)])
     else:
-        AgentShell.try_run(['lctl', 'conf_param', "-d", key])
+        AgentShell.try_run(["lctl", "conf_param", "-d", key])
+
 
 ACTIONS = [set_conf_param]
-CAPABILITIES = ['manage_conf_params']
+CAPABILITIES = ["manage_conf_params"]

--- a/chroma_agent/action_plugins/manage_corosync_common.py
+++ b/chroma_agent/action_plugins/manage_corosync_common.py
@@ -9,11 +9,17 @@ Corosync verification
 
 from collections import namedtuple
 
-from chroma_agent.lib.corosync import get_ring0, generate_ring1_network, detect_ring1, RingDetectionError, CorosyncRingInterface
+from chroma_agent.lib.corosync import (
+    get_ring0,
+    generate_ring1_network,
+    detect_ring1,
+    RingDetectionError,
+    CorosyncRingInterface,
+)
 from iml_common.lib.agent_rpc import agent_error, agent_result_ok, agent_result
 
 
-InterfaceInfo = namedtuple("InterfaceInfo", ['corosync_iface', 'ipaddr', 'prefix'])
+InterfaceInfo = namedtuple("InterfaceInfo", ["corosync_iface", "ipaddr", "prefix"])
 
 
 def get_corosync_autoconfig():
@@ -24,7 +30,7 @@ def get_corosync_autoconfig():
     ring0 = get_ring0()
 
     if not ring0:
-        return agent_error('Failed to detect ring0 interface')
+        return agent_error("Failed to detect ring0 interface")
 
     ring1_ipaddr, ring1_prefix = generate_ring1_network(ring0)
 
@@ -33,27 +39,52 @@ def get_corosync_autoconfig():
     except RingDetectionError as e:
         return agent_error(e.message)
 
-    return agent_result({'interfaces': {ring0.name: {'dedicated': False,
-                                                     'ipaddr': ring0.ipv4_address,
-                                                     'prefix': ring0.ipv4_prefixlen},
-                                        ring1.name: {'dedicated': True,
-                                                     'ipaddr': ring1.ipv4_address,
-                                                     'prefix': ring1.ipv4_prefixlen}},
-                         'mcast_port': ring1.mcastport})
+    return agent_result(
+        {
+            "interfaces": {
+                ring0.name: {
+                    "dedicated": False,
+                    "ipaddr": ring0.ipv4_address,
+                    "prefix": ring0.ipv4_prefixlen,
+                },
+                ring1.name: {
+                    "dedicated": True,
+                    "ipaddr": ring1.ipv4_address,
+                    "prefix": ring1.ipv4_prefixlen,
+                },
+            },
+            "mcast_port": ring1.mcastport,
+        }
+    )
 
 
-def configure_network(ring0_name, ring1_name=None,
-                      ring0_ipaddr=None, ring0_prefix=None,
-                      ring1_ipaddr=None, ring1_prefix=None):
+def configure_network(
+    ring0_name,
+    ring1_name=None,
+    ring0_ipaddr=None,
+    ring0_prefix=None,
+    ring1_ipaddr=None,
+    ring1_prefix=None,
+):
     """
     Configure rings, bring up interfaces and set addresses. no multicast port or peers specified.
     """
-    interfaces = [InterfaceInfo(CorosyncRingInterface(name=ring0_name, ringnumber=0),
-                                ring0_ipaddr, ring0_prefix)]
+    interfaces = [
+        InterfaceInfo(
+            CorosyncRingInterface(name=ring0_name, ringnumber=0),
+            ring0_ipaddr,
+            ring0_prefix,
+        )
+    ]
 
     if ring1_name:
-        interfaces.append(InterfaceInfo(CorosyncRingInterface(ring1_name, ringnumber=1),
-                                        ring1_ipaddr, ring1_prefix))
+        interfaces.append(
+            InterfaceInfo(
+                CorosyncRingInterface(ring1_name, ringnumber=1),
+                ring1_ipaddr,
+                ring1_prefix,
+            )
+        )
 
     for interface in interfaces:
         if interface.ipaddr and interface.ipaddr == ring1_ipaddr:

--- a/chroma_agent/action_plugins/manage_fail_node.py
+++ b/chroma_agent/action_plugins/manage_fail_node.py
@@ -12,5 +12,6 @@ def fail_node(args):
     AgentShell.try_run(["sync"])
     AgentShell.try_run(["init", "0"])
 
+
 ACTIONS = [fail_node]
 CAPABILITIES = []

--- a/chroma_agent/action_plugins/manage_lnet.py
+++ b/chroma_agent/action_plugins/manage_lnet.py
@@ -11,8 +11,8 @@ from chroma_agent.log import console_log
 from chroma_agent.device_plugins.linux_network import LinuxNetworkDevicePlugin
 from iml_common.lib.agent_rpc import agent_ok_or_error
 
-IML_CONFIGURATION_FILE = '/etc/modprobe.d/iml_lnet_module_parameters.conf'
-IML_CONFIGURE_FILE_JSON_HEADER = '##  '
+IML_CONFIGURATION_FILE = "/etc/modprobe.d/iml_lnet_module_parameters.conf"
+IML_CONFIGURE_FILE_JSON_HEADER = "##  "
 
 
 class Module:
@@ -46,7 +46,9 @@ def _remove_module(name, modules):
         # It's not loaded, do nothing.
         return None
 
-    console_log.info("Removing %d dependents of %s : %s" % (len(m.dependents), name, m.dependents))
+    console_log.info(
+        "Removing %d dependents of %s : %s" % (len(m.dependents), name, m.dependents)
+    )
     while m.dependents:
         error = _remove_module(m.dependents.pop(), modules)
 
@@ -55,7 +57,7 @@ def _remove_module(name, modules):
 
     console_log.info("Removing %s" % name)
 
-    error = AgentShell.run_canned_error_message(['rmmod', name])
+    error = AgentShell.run_canned_error_message(["rmmod", name])
 
     if error:
         return error
@@ -85,47 +87,51 @@ def _rmmod_deps(module_name, excpt=[]):
 
 
 def start_lnet():
-    '''
+    """
     Place lnet into the 'up' state.
-    '''
+    """
     console_log.info("Starting LNet")
 
     # modprobe lust is a hack for HYD-1263 - Fix or work around LU-1279 - failure trying to mount
     # should be removed when LU-1279 is fixed
-    return agent_ok_or_error(AgentShell.run_canned_error_message(["lctl", "net", "up"]) or
-                             AgentShell.run_canned_error_message(["modprobe", "lustre"]))
+    return agent_ok_or_error(
+        AgentShell.run_canned_error_message(["lctl", "net", "up"])
+        or AgentShell.run_canned_error_message(["modprobe", "lustre"])
+    )
 
 
 def stop_lnet():
-    '''
+    """
     Place lnet into the 'down' state, any modules that are dependent on lnet being in the 'up' state
     will be unloaded before lnet is stopped.
-    '''
+    """
 
     console_log.info("Stopping LNet")
-    return agent_ok_or_error(_rmmod_deps("lnet", excpt=["ksocklnd", "ko2iblnd"]) or
-                             AgentShell.run_canned_error_message(["lctl", "net", "down"]))
+    return agent_ok_or_error(
+        _rmmod_deps("lnet", excpt=["ksocklnd", "ko2iblnd"])
+        or AgentShell.run_canned_error_message(["lctl", "net", "down"])
+    )
 
 
 def load_lnet():
-    '''
+    """
     Load the lnet modules from disk into memory including an modules using the modprobe command.
-    '''
+    """
     return agent_ok_or_error(AgentShell.run_canned_error_message(["modprobe", "lnet"]))
 
 
 def unload_lnet():
-    '''
+    """
     Unload the lnet modules from memory including an modules that are dependent on the lnet
     module.
 
     Lnet must be stopped before unload_lnet is called.
-    '''
-    return agent_ok_or_error(_rmmod('lnet'))
+    """
+    return agent_ok_or_error(_rmmod("lnet"))
 
 
 def configure_lnet(lnet_configuration):
-    '''
+    """
     :param lnet_configuration: Contains a list of modprobe entries for the modules.conf file
     The entries are a single array in an element name 'modprobe_entries' these elements are
     then writen out to a file before lnet is restarted. The level of restart required is dependent
@@ -136,37 +142,49 @@ def configure_lnet(lnet_configuration):
     by this routine.
 
     :return: None
-    '''
-    with open(IML_CONFIGURATION_FILE, 'w') as file:
-        file.write('# This file is auto-generated for Lustre NID configuration by IML\n' +
-                   '# Do not overwrite this file or edit its contents directly\n')
+    """
+    with open(IML_CONFIGURATION_FILE, "w") as file:
+        file.write(
+            "# This file is auto-generated for Lustre NID configuration by IML\n"
+            + "# Do not overwrite this file or edit its contents directly\n"
+        )
 
-        if (len(lnet_configuration['modprobe_entries']) > 0):
-            file.write('options lnet networks=%s\n' % ','.join(lnet_configuration['modprobe_entries']))
+        if len(lnet_configuration["modprobe_entries"]) > 0:
+            file.write(
+                "options lnet networks=%s\n"
+                % ",".join(lnet_configuration["modprobe_entries"])
+            )
         else:
-            file.write('# No NIDs configured for Lustre\n')
+            file.write("# No NIDs configured for Lustre\n")
 
-        file.write('\n### LNet Configuration Data\n')
+        file.write("\n### LNet Configuration Data\n")
 
-        for line in json.dumps(lnet_configuration, indent = 2).split("\n"):
-            file.write('%s%s\n' % (IML_CONFIGURE_FILE_JSON_HEADER, line))
+        for line in json.dumps(lnet_configuration, indent=2).split("\n"):
+            file.write("%s%s\n" % (IML_CONFIGURE_FILE_JSON_HEADER, line))
 
         # Our preference of course is that we read the results back from lnet, but if lnet is not up we can't
         # so we have to cache the results to use where lnet is not loaded or not up. As soon as it is up the
         # cache will be overwritten by the actual (making it I believe a cache)
-        LinuxNetworkDevicePlugin.cache_results(lnet_configuration = lnet_configuration)
+        LinuxNetworkDevicePlugin.cache_results(lnet_configuration=lnet_configuration)
 
 
 def unconfigure_lnet():
-    '''
+    """
     No parameters just remove the IML configuration file.
-    '''
+    """
     try:
         os.remove(IML_CONFIGURATION_FILE)
     except OSError as e:
-        if e.errno is not 2:        # 2 is no such file
+        if e.errno is not 2:  # 2 is no such file
             raise e
 
 
-ACTIONS = [start_lnet, stop_lnet, load_lnet, unload_lnet, configure_lnet, unconfigure_lnet]
-CAPABILITIES = ['manage_lnet']
+ACTIONS = [
+    start_lnet,
+    stop_lnet,
+    load_lnet,
+    unload_lnet,
+    configure_lnet,
+    unconfigure_lnet,
+]
+CAPABILITIES = ["manage_lnet"]

--- a/chroma_agent/action_plugins/manage_network.py
+++ b/chroma_agent/action_plugins/manage_network.py
@@ -10,14 +10,18 @@ from iml_common.lib.agent_rpc import agent_ok_or_error
 def open_firewall(port, address, proto, description, persist):
     firewall_control = FirewallControl.create()
 
-    return agent_ok_or_error(firewall_control.add_rule(port, proto, description, persist, address))
+    return agent_ok_or_error(
+        firewall_control.add_rule(port, proto, description, persist, address)
+    )
 
 
 def close_firewall(port, address, proto, description, persist):
     firewall_control = FirewallControl.create()
 
-    return agent_ok_or_error(firewall_control.remove_rule(port, proto, description, persist, address))
+    return agent_ok_or_error(
+        firewall_control.remove_rule(port, proto, description, persist, address)
+    )
 
 
 ACTIONS = [open_firewall, close_firewall]
-CAPABILITIES = ['manage_networks']
+CAPABILITIES = ["manage_networks"]

--- a/chroma_agent/action_plugins/manage_node.py
+++ b/chroma_agent/action_plugins/manage_node.py
@@ -32,7 +32,7 @@ def stonith(node):
     p_cfg.get_node(node).fence_reboot()
 
 
-def shutdown_server(halt = True, at_time = "now"):
+def shutdown_server(halt=True, at_time="now"):
     def _shutdown():
         console_log.info("Initiating server shutdown per manager request")
         # This will initiate a "nice" shutdown with a wall from root, etc.
@@ -44,7 +44,7 @@ def shutdown_server(halt = True, at_time = "now"):
     raise CallbackAfterResponse(None, _shutdown)
 
 
-def reboot_server(at_time = "now"):
+def reboot_server(at_time="now"):
     def _reboot():
         console_log.info("Initiating server reboot per manager request")
         # reboot(8) just calls shutdown anyhow.
@@ -54,5 +54,6 @@ def reboot_server(at_time = "now"):
         os._exit(0)
 
     raise CallbackAfterResponse(None, _reboot)
+
 
 ACTIONS = [reboot_server, shutdown_server, fail_node, stonith]

--- a/chroma_agent/action_plugins/manage_ntp.py
+++ b/chroma_agent/action_plugins/manage_ntp.py
@@ -8,7 +8,7 @@ from iml_common.lib.agent_rpc import agent_ok_or_error
 from iml_common.lib.service_control import ServiceControl
 
 
-ntp_service = ServiceControl.create('ntpd')
+ntp_service = ServiceControl.create("ntpd")
 
 
 def unconfigure_ntp():
@@ -34,4 +34,4 @@ def configure_ntp(ntp_server):
 
 
 ACTIONS = [configure_ntp, unconfigure_ntp]
-CAPABILITIES = ['manage_ntp']
+CAPABILITIES = ["manage_ntp"]

--- a/chroma_agent/action_plugins/settings_management.py
+++ b/chroma_agent/action_plugins/settings_management.py
@@ -17,20 +17,20 @@ def set_profile(profile_json):
     profile = json.loads(profile_json)
 
     try:
-        config.set('settings', 'profile', profile)
+        config.set("settings", "profile", profile)
         set_iml_profile(profile.name, profile.bundles, profile.packages)
     except ConfigKeyExistsError:
-        config.update('settings', 'profile', profile)
+        config.update("settings", "profile", profile)
 
 
 def set_agent_config(key, val):
-    agent_settings = config.get('settings', 'agent')
+    agent_settings = config.get("settings", "agent")
     agent_settings[key] = val
-    config.update('settings', 'agent', agent_settings)
+    config.update("settings", "agent", agent_settings)
 
 
 def get_agent_config(key):
-    return config.get('settings', 'agent')[key]
+    return config.get("settings", "agent")[key]
 
 
 def migrate_file(old_path, new_path):
@@ -40,45 +40,49 @@ def migrate_file(old_path, new_path):
 
 def reset_agent_config():
     from chroma_agent import DEFAULT_AGENT_CONFIG
-    config.update('settings', 'agent', DEFAULT_AGENT_CONFIG)
+
+    config.update("settings", "agent", DEFAULT_AGENT_CONFIG)
 
 
 def _convert_agentstore_config():
-    server_conf_path = os.path.join(config.path, 'server_conf')
+    server_conf_path = os.path.join(config.path, "server_conf")
     if os.path.exists(server_conf_path):
         with open(server_conf_path) as f:
             old_server_conf = json.load(f)
-        set_server_url(old_server_conf.get('url').replace("/agent/", "/"))
+        set_server_url(old_server_conf.get("url").replace("/agent/", "/"))
         os.unlink(server_conf_path)
     else:
         try:
-            url = config.get('settings', 'server').get('url').replace("/agent/", "/")
+            url = config.get("settings", "server").get("url").replace("/agent/", "/")
             set_server_url(url)
 
-            config.delete('settings', 'server')
+            config.delete("settings", "server")
         except (KeyError, TypeError):
             pass
 
     crypto_files = map(
         lambda x: (os.path.join(config.path, x), os.path.join(ENV_PATH, x)),
-        ['authority.crt', 'private.pem', 'self.crt'])
+        ["authority.crt", "private.pem", "self.crt"],
+    )
 
     map(lambda x: migrate_file(*x), crypto_files)
 
-    uuid_re = re.compile(r'[0-9a-f]{8}\-[0-9a-f]{4}\-[0-9a-f]{4}\-[0-9a-f]{4}\-[0-9a-f]{12}')
+    uuid_re = re.compile(
+        r"[0-9a-f]{8}\-[0-9a-f]{4}\-[0-9a-f]{4}\-[0-9a-f]{4}\-[0-9a-f]{12}"
+    )
     for entry in os.listdir(config.path):
         if uuid_re.match(entry):
             target_conf_path = os.path.join(config.path, entry)
             with open(target_conf_path) as f:
                 old_target_conf = json.load(f)
-            config.set('targets', entry, old_target_conf)
+            config.set("targets", entry, old_target_conf)
             os.unlink(target_conf_path)
 
 
 def convert_agent_config():
     # Ensure that even if we're upgrading from an older version, we have
     # a default agent config.
-    if 'agent' not in config.sections:
+    if "agent" not in config.sections:
         reset_agent_config()
 
     # < 2.1.0.0
@@ -86,6 +90,10 @@ def convert_agent_config():
 
 
 ACTIONS = [
-    set_server_url, set_agent_config, set_profile, get_agent_config,
-    reset_agent_config, convert_agent_config
+    set_server_url,
+    set_agent_config,
+    set_profile,
+    get_agent_config,
+    reset_agent_config,
+    convert_agent_config,
 ]

--- a/chroma_agent/agent_daemon.py
+++ b/chroma_agent/agent_daemon.py
@@ -18,7 +18,13 @@ from chroma_agent.conf import ENV_PATH
 from chroma_agent.crypto import Crypto
 from chroma_agent.plugin_manager import ActionPluginManager, DevicePluginManager
 from chroma_agent.agent_client import AgentClient
-from chroma_agent.log import daemon_log, daemon_log_setup, console_log_setup, increase_loglevel, decrease_loglevel
+from chroma_agent.log import (
+    daemon_log,
+    daemon_log_setup,
+    console_log_setup,
+    increase_loglevel,
+    decrease_loglevel,
+)
 from chroma_agent.lib.agent_startup_functions import agent_daemon_startup_functions
 from chroma_agent.lib.agent_teardown_functions import agent_daemon_teardown_functions
 
@@ -28,6 +34,7 @@ from chroma_agent.lib.agent_teardown_functions import agent_daemon_teardown_func
 # self-signed certificates when we communicate between
 # the agent and manager.
 import urllib3
+
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
@@ -44,14 +51,15 @@ class ServerProperties(object):
     def boot_time(self):
         for line in open("/proc/stat").readlines():
             name, val = line.split(" ", 1)
-            if name == 'btime':
+            if name == "btime":
                 return datetime.datetime.fromtimestamp(int(val))
 
 
 def main():
     """handle unexpected exceptions"""
     parser = argparse.ArgumentParser(
-        description="Integrated Manager for Lustre software Agent")
+        description="Integrated Manager for Lustre software Agent"
+    )
 
     parser.add_argument("--publish-zconf", action="store_true")
     parser.parse_args()
@@ -69,7 +77,8 @@ def main():
         except KeyError as e:
             daemon_log.error(
                 "No configuration found (must be registered before running the agent service), "
-                "details: %s" % e)
+                "details: %s" % e
+            )
             return
 
         if config.profile_managed is False:
@@ -80,11 +89,16 @@ def main():
             # constructor. Well, we could, but it would only work some
             # of the time and that would be even more awful.
             import chroma_agent.plugin_manager
-            chroma_agent.plugin_manager.EXCLUDED_PLUGINS += ['corosync']
 
-        agent_client = AgentClient(url, ActionPluginManager(),
-                                   DevicePluginManager(), ServerProperties(),
-                                   Crypto(ENV_PATH))
+            chroma_agent.plugin_manager.EXCLUDED_PLUGINS += ["corosync"]
+
+        agent_client = AgentClient(
+            url,
+            ActionPluginManager(),
+            DevicePluginManager(),
+            ServerProperties(),
+            Crypto(ENV_PATH),
+        )
 
         def teardown_callback(*args, **kwargs):
             agent_client.stop()
@@ -105,8 +119,8 @@ def main():
             agent_client.stopped.wait(timeout=10)
 
         agent_client.join()
-    except Exception, e:
-        backtrace = '\n'.join(traceback.format_exception(*(sys.exc_info())))
+    except Exception as e:
+        backtrace = "\n".join(traceback.format_exception(*(sys.exc_info())))
         daemon_log.error("Unhandled exception: %s" % backtrace)
 
     # Call any agent daemon teardown methods that were registered.

--- a/chroma_agent/cli.py
+++ b/chroma_agent/cli.py
@@ -28,18 +28,23 @@ def raw_result(wrapped):
     """
     Decorator for functions whose output should not be JSON-serialized.
     """
+
     def wrapper(*args, **kwargs):
         result = wrapped(*args, **kwargs)
-        return {'raw_result': result}
+        return {"raw_result": result}
 
     # These contortions are necessary to retain compatibility with
     # argparse's ability to generate CLI options by signature inspection.
     import functools
+
     wrapped_signature = inspect.getargspec(wrapped)
     formatted_args = inspect.formatargspec(*wrapped_signature)
     compat_name = "_%s" % wrapped.func_name
-    compat_def = 'lambda %s: %s%s' % (formatted_args.lstrip('(').rstrip(')'),
-                                      compat_name, formatted_args)
+    compat_def = "lambda %s: %s%s" % (
+        formatted_args.lstrip("(").rstrip(")"),
+        compat_name,
+        formatted_args,
+    )
     compat_fn = eval(compat_def, {compat_name: wrapper})
     return functools.wraps(wrapped)(compat_fn)
 
@@ -57,17 +62,17 @@ def _register_function(parser, name, fn):
     # so functions that require it cannot be called from the CLI
     # In future we might want to 'create' a context so these functions can be called, but today the only
     # usages do not make sense to call from the CLI.
-    if 'agent_daemon_context' in argspec[0]:
+    if "agent_daemon_context" in argspec[0]:
         return
 
-    p = parser.add_parser(name, help = fn.__doc__)
+    p = parser.add_parser(name, help=fn.__doc__)
 
     def wrap(args):
         args = vars(args)
-        del args['func']
+        del args["func"]
         return fn(**args)
 
-    p.set_defaults(func = wrap)
+    p.set_defaults(func=wrap)
 
     if argspec.defaults is not None:
         positional_arg_count = len(argspec.args) - len(argspec.defaults)
@@ -76,18 +81,20 @@ def _register_function(parser, name, fn):
 
     for i, arg in enumerate(argspec.args):
         if i < positional_arg_count:
-            p.add_argument('--%s' % arg, required = True)
+            p.add_argument("--%s" % arg, required=True)
         else:
             if isinstance(argspec.defaults[i - positional_arg_count], bool):
-                p.add_argument('--%s' % arg, required = False, action = 'store_true')
+                p.add_argument("--%s" % arg, required=False, action="store_true")
             else:
-                p.add_argument('--%s' % arg, required = False)
+                p.add_argument("--%s" % arg, required=False)
 
 
 def main():
     configure_logging()
 
-    parser = argparse.ArgumentParser(description="Integrated Manager for Lustre software Agent")
+    parser = argparse.ArgumentParser(
+        description="Integrated Manager for Lustre software Agent"
+    )
     subparsers = parser.add_subparsers()
 
     for command, fn in ActionPluginManager().commands.items():
@@ -98,22 +105,25 @@ def main():
         args = parser.parse_args()
         result = args.func(args)
         try:
-            print result['raw_result']
+            print(result["raw_result"])
         except (TypeError, KeyError):
-            sys.stderr.write(json.dumps(AgentShell.thread_state.get_subprocesses(), indent = 2))
+            sys.stderr.write(
+                json.dumps(AgentShell.thread_state.get_subprocesses(), indent=2)
+            )
             sys.stderr.write("\n\n")
-            print json.dumps({'success': True, 'result': result}, indent = 2)
+            print(json.dumps({"success": True, "result": result}, indent=2))
     except SystemExit:
         raise
     except Exception:
         exc_info = sys.exc_info()
-        backtrace = '\n'.join(traceback.format_exception(*(exc_info or sys.exc_info())))
+        backtrace = "\n".join(traceback.format_exception(*(exc_info or sys.exc_info())))
         sys.stderr.write("%s\n" % backtrace)
 
-        sys.stderr.write(json.dumps(AgentShell.thread_state.get_subprocesses(), indent = 2))
+        sys.stderr.write(
+            json.dumps(AgentShell.thread_state.get_subprocesses(), indent=2)
+        )
         sys.stderr.write("\n\n")
-        print json.dumps({'success': False,
-                          'backtrace': backtrace}, indent=2)
+        print(json.dumps({"success": False, "backtrace": backtrace}, indent=2))
         # NB having caught the exception, we will finally return 0.  This
         # is done in order to distinguish between internal errors in
         # chroma-agent (nonzero return value) and exceptions while running

--- a/chroma_agent/conf.py
+++ b/chroma_agent/conf.py
@@ -4,29 +4,29 @@
 
 import os
 
-ENV_PATH = '/etc/iml'
+ENV_PATH = "/etc/iml"
 
 
 def set_server_url(url):
     if not os.path.exists(ENV_PATH):
         os.makedirs(ENV_PATH)
 
-    with open('{}/manager-url.conf'.format(ENV_PATH), 'w+') as f:
+    with open("{}/manager-url.conf".format(ENV_PATH), "w+") as f:
         f.write("IML_MANAGER_URL={}\n".format(url))
 
 
 def remove_server_url():
-    os.unlink('{}/manager-url.conf'.format(ENV_PATH))
+    os.unlink("{}/manager-url.conf".format(ENV_PATH))
 
 
 def set_iml_profile(name, repos, packages):
-    '''
+    """
     Setup /etc/iml/profile.conf
-    '''
+    """
     if not os.path.exists(ENV_PATH):
         os.makedirs(ENV_PATH)
 
-    with open('{}/profile.conf'.format(ENV_PATH), 'w+') as f:
+    with open("{}/profile.conf".format(ENV_PATH), "w+") as f:
         if name:
             f.write("IML_PROFILE_NAME={}\n".format(name))
         if repos:
@@ -36,4 +36,4 @@ def set_iml_profile(name, repos, packages):
 
 
 def remove_iml_profile():
-    os.unlink('{}/profile.conf'.format(ENV_PATH))
+    os.unlink("{}/profile.conf".format(ENV_PATH))

--- a/chroma_agent/config_store.py
+++ b/chroma_agent/config_store.py
@@ -1,4 +1,3 @@
-
 # Copyright (c) 2018 DDN. All rights reserved.
 # Use of this source code is governed by a MIT-style
 # license that can be found in the LICENSE file.
@@ -19,7 +18,10 @@ class ConfigKeyExistsError(Exception):
         self.key = key
 
     def __str__(self):
-        return "The key '%s' already exists in section '%s'. Please use update() if that's what you intended." % (self.key, self.section)
+        return (
+            "The key '%s' already exists in section '%s'. Please use update() if that's what you intended."
+            % (self.key, self.section)
+        )
 
 
 class InvalidConfigIdentifier(Exception):
@@ -33,7 +35,7 @@ class InvalidConfigIdentifier(Exception):
 class ConfigStore(object):
     def _create_path(self, path):
         try:
-            os.makedirs(path, 0755)
+            os.makedirs(path, 0o755)
         except OSError as e:
             if e.errno != errno.EEXIST:
                 raise
@@ -71,9 +73,13 @@ class ConfigStore(object):
     @property
     def sections(self):
         with self._lock:
-            return sorted([os.path.basename(e)
-                           for e in os.listdir(self.path)
-                           if os.path.isdir(os.path.join(self.path, e))])
+            return sorted(
+                [
+                    os.path.basename(e)
+                    for e in os.listdir(self.path)
+                    if os.path.isdir(os.path.join(self.path, e))
+                ]
+            )
 
     def get_section_keys(self, section):
         dir = os.path.join(self.path, self._ck_str(section))
@@ -86,13 +92,18 @@ class ConfigStore(object):
 
     def get_section(self, section):
         with self._lock:
-            return dict([(key, self.get(section, key))
-                         for key in self.get_section_keys(section)])
+            return dict(
+                [
+                    (key, self.get(section, key))
+                    for key in self.get_section_keys(section)
+                ]
+            )
 
     def get_all(self):
         with self._lock:
-            return dict([(section, self.get_section(section))
-                         for section in self.sections])
+            return dict(
+                [(section, self.get_section(section)) for section in self.sections]
+            )
 
     def delete_section(self, section):
         dir = os.path.join(self.path, self._ck_str(section))
@@ -111,8 +122,7 @@ class ConfigStore(object):
         safe_key = self._encode_key(key)
 
         with self._lock:
-            dir = self._create_path(os.path.join(self.path,
-                                                 self._ck_str(section)))
+            dir = self._create_path(os.path.join(self.path, self._ck_str(section)))
 
             if not update and key in self.get_section_keys(section):
                 raise ConfigKeyExistsError(section, key)
@@ -142,12 +152,17 @@ class ConfigStore(object):
                     if not section in self.sections:
                         raise TypeError("Invalid config section: '%s'" % section)
                     elif not key in self.get_section_keys(section):
-                        raise KeyError("Invalid key '%s' for config section '%s'"
-                                       % (key, section))
+                        raise KeyError(
+                            "Invalid key '%s' for config section '%s'" % (key, section)
+                        )
                 raise
             except Exception as e:
-                daemon_log.warn("Json error %s, file was %s" % (e, os.path.join(dir, safe_key)))
-                daemon_log.warn("File contents %s" % open(os.path.join(dir, safe_key), "r").read())
+                daemon_log.warn(
+                    "Json error %s, file was %s" % (e, os.path.join(dir, safe_key))
+                )
+                daemon_log.warn(
+                    "File contents %s" % open(os.path.join(dir, safe_key), "r").read()
+                )
                 raise
 
     def delete(self, section, key):
@@ -166,6 +181,6 @@ class ConfigStore(object):
         :return: True if profile is managed False if not or no profile
         """
         try:
-            return self.get('settings', 'profile').get('managed', False)
+            return self.get("settings", "profile").get("managed", False)
         except (KeyError, TypeError):
             return False

--- a/chroma_agent/crypto.py
+++ b/chroma_agent/crypto.py
@@ -21,7 +21,9 @@ class Crypto(object):
         """Return a path to a PEM file"""
         if not os.path.exists(self.PRIVATE_KEY_FILE):
             console_log.info("Generating private key")
-            AgentShell.try_run(['openssl', 'genrsa', '-out', self.PRIVATE_KEY_FILE, '2048', '-sha256'])
+            AgentShell.try_run(
+                ["openssl", "genrsa", "-out", self.PRIVATE_KEY_FILE, "2048", "-sha256"]
+            )
 
         return self.PRIVATE_KEY_FILE
 
@@ -41,21 +43,32 @@ class Crypto(object):
 
     def generate_csr(self, common_name):
         """Return a CSR as a string"""
-        output = AgentShell.try_run(["openssl", "req", "-new", "-sha256", "-subj", "/C=/ST=/L=/O=/CN=%s" % common_name, "-key", self.private_key_file])
+        output = AgentShell.try_run(
+            [
+                "openssl",
+                "req",
+                "-new",
+                "-sha256",
+                "-subj",
+                "/C=/ST=/L=/O=/CN=%s" % common_name,
+                "-key",
+                self.private_key_file,
+            ]
+        )
         return output.strip()
 
     def install_authority(self, ca):
-        open(self.AUTHORITY_FILE, 'w').write(ca)
+        open(self.AUTHORITY_FILE, "w").write(ca)
 
     def install_certificate(self, cert):
         """Install a certificate for our private key, signed by the authority"""
-        open(self.CERTIFICATE_FILE, 'w').write(cert)
+        open(self.CERTIFICATE_FILE, "w").write(cert)
 
     def delete(self):
         for path in [self.PRIVATE_KEY_FILE, self.CERTIFICATE_FILE, self.AUTHORITY_FILE]:
             try:
                 os.unlink(path)
-            except OSError, e:
+            except OSError as e:
                 if e.errno == errno.ENOENT:
                     pass
                 else:

--- a/chroma_agent/device_plugins/audit/__init__.py
+++ b/chroma_agent/device_plugins/audit/__init__.py
@@ -9,12 +9,13 @@ def local_audit_classes():
 
     classes = []
     classes.extend(lustre.local_audit_classes())
-    classes.append(getattr(node, 'NodeAudit'))
+    classes.append(getattr(node, "NodeAudit"))
     return classes
 
 
 class BaseAudit(object):
     """Base Audit class."""
+
     def __init__(self, **kwargs):
         self.raw_metrics = {}
 

--- a/chroma_agent/device_plugins/audit/local.py
+++ b/chroma_agent/device_plugins/audit/local.py
@@ -16,8 +16,10 @@ class LocalAudit(BaseAudit, FileSystemMixin):
 
     # FIXME: This probably ought to be a memorized property, but I'm lazy.
     def audit_classes(self):
-        if not hasattr(self, 'audit_classes_list'):
-            self.audit_classes_list = chroma_agent.device_plugins.audit.local_audit_classes()
+        if not hasattr(self, "audit_classes_list"):
+            self.audit_classes_list = (
+                chroma_agent.device_plugins.audit.local_audit_classes()
+            )
         return self.audit_classes_list
 
     # Flagrantly "borrowed" from:
@@ -58,11 +60,13 @@ class LocalAudit(BaseAudit, FileSystemMixin):
         for cls in self.audit_classes():
             audit = cls()
             audit_metrics = audit.metrics()
-            agg_raw = self.__mergedicts(agg_raw, audit_metrics['raw'])
+            agg_raw = self.__mergedicts(agg_raw, audit_metrics["raw"])
 
-        return {'raw': agg_raw}
+        return {"raw": agg_raw}
 
     @exceptionSandBox(console_log, {})
     def properties(self):
         """Returns merged properties suitable for host validation."""
-        return dict(item for cls in self.audit_classes() for item in cls().properties().items())
+        return dict(
+            item for cls in self.audit_classes() for item in cls().properties().items()
+        )

--- a/chroma_agent/device_plugins/audit/mixins.py
+++ b/chroma_agent/device_plugins/audit/mixins.py
@@ -12,6 +12,7 @@ class FileSystemMixin(object):
     filesystem.  The fscontext property provides a way to override the
     default filesystem context ("/") for unit testing.
     """
+
     # Unit tests should patch this attribute when using fixture data.
     fscontext = "/"
 
@@ -37,7 +38,7 @@ class FileSystemMixin(object):
 
         filename = self.abs(filename)
 
-        if (not os.path.isfile(filename)):
+        if not os.path.isfile(filename):
             filename = filename.replace("osd-ldiskfs", "osd-zfs")
 
         for line in open(filename):

--- a/chroma_agent/device_plugins/audit/node.py
+++ b/chroma_agent/device_plugins/audit/node.py
@@ -16,22 +16,25 @@ class NodeAudit(BaseAudit, FileSystemMixin):
     def __init__(self, **kwargs):
         super(NodeAudit, self).__init__(**kwargs)
 
-        self.raw_metrics['node'] = {}
+        self.raw_metrics["node"] = {}
 
     def parse_meminfo(self):
         """Returns a dict representation of /proc/meminfo"""
-        return dict((k, int(re.sub('[^\d]*', '', v))) for k, v in
-                    [re.split(':\s+', line) for line in
-                        self.read_lines('/proc/meminfo')])
+        return dict(
+            (k, int(re.sub("[^\d]*", "", v)))
+            for k, v in [
+                re.split(":\s+", line) for line in self.read_lines("/proc/meminfo")
+            ]
+        )
 
     def parse_cpustats(self):
         """Reads the first string of /proc/stat and returns a dict
         containing used/total cpu slices."""
-        cpu_str = self.read_string('/proc/stat')
-        slices = [int(val) for val in re.split('\s+', cpu_str)[1:]]
-                                # 2.6+
-                                                      # 2.6.11+
-                                                             # 2.6.24+
+        cpu_str = self.read_string("/proc/stat")
+        slices = [int(val) for val in re.split("\s+", cpu_str)[1:]]
+        # 2.6+
+        # 2.6.11+
+        # 2.6.24+
         # usr, nice, sys, idle, iowait, irq, softirq, steal, guest
         # steal seems to only be used on s390; we can ignore it
         # guest is included in user, so we shouldn't double-count it
@@ -40,12 +43,18 @@ class NodeAudit(BaseAudit, FileSystemMixin):
         system = slices[2] + sum(slices[5:6])
         idle = slices[3]
         iowait = slices[4]
-        return {'user': user, 'system': system, 'idle': idle, 'iowait': iowait, 'total': total}
+        return {
+            "user": user,
+            "system": system,
+            "idle": idle,
+            "iowait": iowait,
+            "total": total,
+        }
 
     def _gather_raw_metrics(self):
-        self.raw_metrics['node']['hostname'] = socket.gethostname()
-        self.raw_metrics['node']['meminfo'] = self.parse_meminfo()
-        self.raw_metrics['node']['cpustats'] = self.parse_cpustats()
+        self.raw_metrics["node"]["hostname"] = socket.gethostname()
+        self.raw_metrics["node"]["meminfo"] = self.parse_meminfo()
+        self.raw_metrics["node"]["cpustats"] = self.parse_cpustats()
 
     def metrics(self):
         """Returns a hash of metric values."""
@@ -57,12 +66,21 @@ class NodeAudit(BaseAudit, FileSystemMixin):
 
         If the fetched property is expensive to compute, it should be cached / updated less frequently.
         """
-        zfs_not_installed, stdout, stderr = AgentShell.run_old(['which', 'zfs'])
+        zfs_not_installed, stdout, stderr = AgentShell.run_old(["which", "zfs"])
 
-        return {'zfs_installed': not zfs_not_installed,
-                'distro': platform.linux_distribution()[0],
-                'distro_version': float('.'.join(platform.linux_distribution()[1].split('.')[:2])),
-                'python_version_major_minor': float("%s.%s" % (platform.python_version_tuple()[0],
-                                                               platform.python_version_tuple()[1])),
-                'python_patchlevel': int(platform.python_version_tuple()[2]),
-                'kernel_version': platform.release()}
+        return {
+            "zfs_installed": not zfs_not_installed,
+            "distro": platform.linux_distribution()[0],
+            "distro_version": float(
+                ".".join(platform.linux_distribution()[1].split(".")[:2])
+            ),
+            "python_version_major_minor": float(
+                "%s.%s"
+                % (
+                    platform.python_version_tuple()[0],
+                    platform.python_version_tuple()[1],
+                )
+            ),
+            "python_patchlevel": int(platform.python_version_tuple()[2]),
+            "kernel_version": platform.release(),
+        }

--- a/chroma_agent/device_plugins/block_devices.py
+++ b/chroma_agent/device_plugins/block_devices.py
@@ -15,15 +15,15 @@ from toolz.functoolz import pipe, curry
 from chroma_agent.lib.shell import AgentShell
 from iml_common.blockdevices.blockdevice import BlockDevice
 
-DeviceMaps = namedtuple('device_maps', 'block_devices zfspools')
+DeviceMaps = namedtuple("device_maps", "block_devices zfspools")
 
 # Python errno doesn't include this code
 errno.NO_MEDIA_ERRNO = 123
 
-DEV_PATH = re.compile('^/dev/[^/]+$')
-DISK_BY_ID_PATH = re.compile('^/dev/disk/by-id/')
-DISK_BY_PATH_PATH = re.compile('^/dev/disk/by-path/')
-MAPPER_PATH = re.compile('^/dev/mapper/')
+DEV_PATH = re.compile("^/dev/[^/]+$")
+DISK_BY_ID_PATH = re.compile("^/dev/disk/by-id/")
+DISK_BY_PATH_PATH = re.compile("^/dev/disk/by-path/")
+MAPPER_PATH = re.compile("^/dev/mapper/")
 
 
 def scanner_cmd(cmd):
@@ -37,7 +37,7 @@ def scanner_cmd(cmd):
     client.connect_ex("/var/run/device-scanner.sock")
     client.sendall(json.dumps(cmd) + "\n")
 
-    out = ''
+    out = ""
 
     while True:
         out += client.recv(1024)
@@ -56,37 +56,37 @@ def get_default(prop, default_value, x):
 
 
 def get_major_minor(x):
-    return "%s:%s" % (x.get('major'), x.get('minor'))
+    return "%s:%s" % (x.get("major"), x.get("minor"))
 
 
 def as_device(x):
-    paths = get_default('paths', [], x)
+    paths = get_default("paths", [], x)
     path = next(iter(paths), None)
 
     return {
-        'major_minor': get_major_minor(x),
-        'path': path,
-        'paths': paths,
-        'serial_80': x.get('scsi80'),
-        'serial_83': x.get('scsi83'),
-        'size': int(get_default('size', 0, x)),
-        'filesystem_type': x.get('idFsType'),
-        'filesystem_usage': x.get('idFsUsage'),
-        'device_type': x.get('devType'),
-        'device_path': x.get('devPath'),
-        'partition_number': x.get('idPartEntryNumber'),
-        'is_ro': x.get('isReadOnly'),
-        'parent': None,
-        'dm_multipath': x.get('dmMultipathDevicePath'),
-        'dm_lv': x.get('dmLvName'),
-        'dm_vg': x.get('dmVgName'),
-        'lv_uuid': x.get('lvUuid'),
-        'vg_uuid': x.get('vgUuid'),
-        'dm_slave_mms': get_default('dmSlaveMms', [], x),
-        'dm_vg_size': x.get('dmVgSize'),
-        'md_uuid': x.get('mdUuid'),
-        'md_device_paths': x.get('mdDevices'),
-        'is_mpath': get_default('isMpath', False, x),
+        "major_minor": get_major_minor(x),
+        "path": path,
+        "paths": paths,
+        "serial_80": x.get("scsi80"),
+        "serial_83": x.get("scsi83"),
+        "size": int(get_default("size", 0, x)),
+        "filesystem_type": x.get("idFsType"),
+        "filesystem_usage": x.get("idFsUsage"),
+        "device_type": x.get("devType"),
+        "device_path": x.get("devPath"),
+        "partition_number": x.get("idPartEntryNumber"),
+        "is_ro": x.get("isReadOnly"),
+        "parent": None,
+        "dm_multipath": x.get("dmMultipathDevicePath"),
+        "dm_lv": x.get("dmLvName"),
+        "dm_vg": x.get("dmVgName"),
+        "lv_uuid": x.get("lvUuid"),
+        "vg_uuid": x.get("vgUuid"),
+        "dm_slave_mms": get_default("dmSlaveMms", [], x),
+        "dm_vg_size": x.get("dmVgSize"),
+        "md_uuid": x.get("mdUuid"),
+        "md_device_paths": x.get("mdDevices"),
+        "is_mpath": get_default("isMpath", False, x),
     }
 
 
@@ -95,61 +95,61 @@ def get_parent_path(p):
 
 
 def find_device_by_device_path(p, xs):
-    return next((d for d in xs if d['device_path'] == p), None)
+    return next((d for d in xs if d["device_path"] == p), None)
 
 
 def mutate_parent_prop(xs):
-    disks = [x for x in xs if x['device_type'] == 'disk']
-    partitions = [x for x in xs if x['device_type'] == 'partition']
+    disks = [x for x in xs if x["device_type"] == "disk"]
+    partitions = [x for x in xs if x["device_type"] == "partition"]
 
     for x in partitions:
-        parent_path = get_parent_path(x['device_path'])
+        parent_path = get_parent_path(x["device_path"])
         device = find_device_by_device_path(parent_path, disks)
 
         if device:
-            x['parent'] = device['major_minor']
+            x["parent"] = device["major_minor"]
 
 
 def filter_device(x):
     # Exclude zero-sized devices
-    if x['size'] == 0 or x['is_ro']:
+    if x["size"] == 0 or x["is_ro"]:
         return False
 
     return True
 
 
 def create_device_list(device_dict):
-    return pipe(device_dict.itervalues(), cmap(as_device),
-                cfilter(filter_device), list)
+    return pipe(device_dict.itervalues(), cmap(as_device), cfilter(filter_device), list)
 
 
 def lvm_populate(device):
     """ Create vg and lv entries for devices with dm attributes """
-    vg_name, vg_size, lv_name, lv_uuid, vg_uuid, lv_size, lv_mm, lv_slave_mms = \
-        map(device.get,
-            ('dm_vg', 'dm_vg_size', 'dm_lv', 'lv_uuid', 'vg_uuid', 'size', 'major_minor', 'dm_slave_mms'))
+    vg_name, vg_size, lv_name, lv_uuid, vg_uuid, lv_size, lv_mm, lv_slave_mms = map(
+        device.get,
+        (
+            "dm_vg",
+            "dm_vg_size",
+            "dm_lv",
+            "lv_uuid",
+            "vg_uuid",
+            "size",
+            "major_minor",
+            "dm_slave_mms",
+        ),
+    )
 
-    vg = {
-        'name': vg_name,
-        'uuid': vg_uuid,
-        'size': int(vg_size),
-        'pvs_major_minor': []
-    }
+    vg = {"name": vg_name, "uuid": vg_uuid, "size": int(vg_size), "pvs_major_minor": []}
 
     [
-        vg['pvs_major_minor'].append(mm) for mm in lv_slave_mms
-        if mm not in vg['pvs_major_minor']
+        vg["pvs_major_minor"].append(mm)
+        for mm in lv_slave_mms
+        if mm not in vg["pvs_major_minor"]
     ]
 
     # Do this to cache the device, type see blockdevice and filesystem for info.
-    BlockDevice('lvm_volume', '/dev/mapper/%s-%s' % (vg_name, lv_name))
+    BlockDevice("lvm_volume", "/dev/mapper/%s-%s" % (vg_name, lv_name))
 
-    lv = {
-        'name': lv_name,
-        'uuid': lv_uuid,
-        'size': lv_size,
-        'block_device': lv_mm
-    }
+    lv = {"name": lv_name, "uuid": lv_uuid, "size": lv_size, "block_device": lv_mm}
 
     return vg, lv
 
@@ -157,25 +157,25 @@ def lvm_populate(device):
 @curry
 def link_dm_slaves(block_device_nodes, ndt, x):
     """ link dm slave devices back to the mapper devices using mm to look up path """
-    for slave_mm in x.get('dm_slave_mms', []):
+    for slave_mm in x.get("dm_slave_mms", []):
         ndt.add_normalized_devices(
-            filter(DISK_BY_ID_PATH.match,
-                   block_device_nodes[slave_mm]['paths']),
-            filter(MAPPER_PATH.match, x.get('paths')))
+            filter(DISK_BY_ID_PATH.match, block_device_nodes[slave_mm]["paths"]),
+            filter(MAPPER_PATH.match, x.get("paths")),
+        )
 
 
 def parse_dm_devs(xs, block_device_nodes, ndt):
     vgs = {}
     lvs = defaultdict(dict)
 
-    results = [lvm_populate(x) for x in xs if x.get('dm_lv') is not None]
+    results = [lvm_populate(x) for x in xs if x.get("dm_lv") is not None]
 
     for vg, lv in results:
-        vgs[vg['name']] = vg
-        lvs[vg['name']][lv['name']] = lv
+        vgs[vg["name"]] = vg
+        lvs[vg["name"]][lv["name"]] = lv
 
     c_link_dm_slaves = link_dm_slaves(block_device_nodes, ndt)
-    map(c_link_dm_slaves, filter(lambda x: x['is_mpath'], xs))
+    map(c_link_dm_slaves, filter(lambda x: x["is_mpath"], xs))
 
     return ndt, vgs, lvs
 
@@ -184,22 +184,21 @@ def parse_mdraid_devs(xs, node_block_devices, ndt):
     mds = {}
 
     for x in xs:
-        mds[x['md_uuid']] = {
-            'path':
-            x['path'],
-            'block_device':
-            x['major_minor'],
-            'drives':
-            paths_to_major_minors(node_block_devices, ndt,
-                                  x['md_device_paths'])
+        mds[x["md_uuid"]] = {
+            "path": x["path"],
+            "block_device": x["major_minor"],
+            "drives": paths_to_major_minors(
+                node_block_devices, ndt, x["md_device_paths"]
+            ),
         }
 
         # Finally add these devices to the canonical path list.
         ndt.add_normalized_devices(
-            filter(DISK_BY_ID_PATH.match, x['paths']),
-            filter(DEV_PATH.match, x['paths']))
+            filter(DISK_BY_ID_PATH.match, x["paths"]),
+            filter(DEV_PATH.match, x["paths"]),
+        )
 
-        ndt.add_normalized_devices(x['md_device_paths'], [x['path']])
+        ndt.add_normalized_devices(x["md_device_paths"], [x["path"]])
 
     return ndt, mds
 
@@ -211,7 +210,7 @@ class NormalizedDeviceTable(object):
         map(self.build_normalized_table_from_device, xs)
 
     def build_normalized_table_from_device(self, x):
-        paths = x['paths']
+        paths = x["paths"]
 
         dev_paths = filter(DEV_PATH.match, paths)
         disk_by_id_paths = filter(DISK_BY_ID_PATH.match, paths)
@@ -233,7 +232,7 @@ class NormalizedDeviceTable(object):
             self.table[from_path] = to_path
 
     def find_normalized_start(self, device_fullpath):
-        '''
+        """
         :param device_fullpath: The device_path being search for
         :return: Given /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_WD-WMAP3333333
                 returns
@@ -241,11 +240,10 @@ class NormalizedDeviceTable(object):
                 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_WD-WMAP3333333-part1
                 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_WD-WMAP3333333-part9
                 etc.
-        '''
+        """
 
         return [
-            value for value in self.table.values()
-            if value.startswith(device_fullpath)
+            value for value in self.table.values() if value.startswith(device_fullpath)
         ]
 
     def normalized_device_path(self, device_path):
@@ -268,8 +266,7 @@ class NormalizedDeviceTable(object):
         # it repeats.
         visited = set()
 
-        while (normalized_path not in visited) and (
-                normalized_path in self.table):
+        while (normalized_path not in visited) and (normalized_path in self.table):
             visited.add(normalized_path)
             normalized_path = self.table[normalized_path]
 
@@ -277,25 +274,25 @@ class NormalizedDeviceTable(object):
 
 
 def parse_sys_block(device_map):
-    xs = create_device_list(device_map['blockDevices'])
+    xs = create_device_list(device_map["blockDevices"])
 
     mutate_parent_prop(xs)
 
     node_block_devices = reduce(
-        lambda d, x: dict(d, **{x['path']: x['major_minor']}), xs, {})
+        lambda d, x: dict(d, **{x["path"]: x["major_minor"]}), xs, {}
+    )
 
-    block_device_nodes = reduce(lambda d, x: dict(d, **{x['major_minor']: x}),
-                                xs, {})
+    block_device_nodes = reduce(lambda d, x: dict(d, **{x["major_minor"]: x}), xs, {})
 
     ndt = NormalizedDeviceTable(xs)
 
     (ndt, _, _) = parse_dm_devs(
-        filter(lambda x: x.get('lv_uuid') is not None, xs), block_device_nodes,
-        ndt)
+        filter(lambda x: x.get("lv_uuid") is not None, xs), block_device_nodes, ndt
+    )
 
     (ndt, _) = parse_mdraid_devs(
-        filter(lambda x: x.get('md_uuid') is not None, xs), node_block_devices,
-        ndt)
+        filter(lambda x: x.get("md_uuid") is not None, xs), node_block_devices, ndt
+    )
 
     return ndt
 
@@ -311,11 +308,11 @@ def parse_local_mounts(xs):
     """ process block device info returned by device-scanner to produce
         a legacy version of local mounts
     """
-    return [(d['source'], d['target'], d['fstype']) for d in xs]
+    return [(d["source"], d["target"], d["fstype"]) for d in xs]
 
 
 def get_local_mounts():
-    xs = scanner_cmd("Stream")['localMounts']
+    xs = scanner_cmd("Stream")["localMounts"]
     return parse_local_mounts(xs)
 
 

--- a/chroma_agent/device_plugins/corosync.py
+++ b/chroma_agent/device_plugins/corosync.py
@@ -17,6 +17,7 @@ from iml_common.lib.date_time import IMLDateTime
 try:
     # Python 2.7
     from xml.etree.ElementTree import ParseError
+
     ParseError  # silence pyflakes
 except ImportError:
     # Python 2.6
@@ -45,8 +46,7 @@ class CorosyncPlugin(DevicePlugin):
 
     # This is the message that crm_mon will report
     # when corosync is not running
-    COROSYNC_CONNECTION_FAILURE = ("Connection to cluster failed: "
-                                   "connection failed")
+    COROSYNC_CONNECTION_FAILURE = "Connection to cluster failed: " "connection failed"
 
     def _parse_crm_as_xml(self, raw):
         """ Parse the crm_mon response
@@ -66,25 +66,34 @@ class CorosyncPlugin(DevicePlugin):
             return_dict = {}
 
             #  Got node info, pack it up and return
-            tm_str = root.find('summary/last_update').get('time')
-            tm_datetime = IMLDateTime.strptime(tm_str, '%a %b %d %H:%M:%S %Y')
-            return_dict.update({'datetime': IMLDateTime.convert_datetime_to_utc(tm_datetime).strftime("%Y-%m-%dT%H:%M:%S+00:00")})
+            tm_str = root.find("summary/last_update").get("time")
+            tm_datetime = IMLDateTime.strptime(tm_str, "%a %b %d %H:%M:%S %Y")
+            return_dict.update(
+                {
+                    "datetime": IMLDateTime.convert_datetime_to_utc(
+                        tm_datetime
+                    ).strftime("%Y-%m-%dT%H:%M:%S+00:00")
+                }
+            )
 
             nodes = {}
             for node in root.findall("nodes/node"):
                 host = node.get("name")
                 nodes.update({host: node.attrib})
 
-            return_dict['nodes'] = nodes
+            return_dict["nodes"] = nodes
 
-            return_dict['options'] = {
-                'stonith_enabled': False
-            }
+            return_dict["options"] = {"stonith_enabled": False}
 
-            cluster_options = root.find('summary/cluster_options')
+            cluster_options = root.find("summary/cluster_options")
 
             if cluster_options is not None:
-                return_dict['options'].update({'stonith_enabled': cluster_options.get('stonith-enabled') == 'true'})
+                return_dict["options"].update(
+                    {
+                        "stonith_enabled": cluster_options.get("stonith-enabled")
+                        == "true"
+                    }
+                )
 
         return return_dict
 
@@ -95,17 +104,18 @@ class CorosyncPlugin(DevicePlugin):
         If the return value is unexpected, log a warning, and return None
         """
 
-        crm_command = ['crm_mon', '--one-shot', '--as-xml']
+        crm_command = ["crm_mon", "--one-shot", "--as-xml"]
         try:
             rc, stdout, stderr = AgentShell.run_old(crm_command)
-        except OSError, e:
+        except OSError as e:
             # ENOENT is fine here.  Pacemaker might not be installed yet.
             if e.errno != errno.ENOENT:
                 raise
 
         if rc not in [0, 10]:  # 10 Corosync is not running on this node
-            daemon_log.warning("rc=%s running '%s': '%s' '%s'" %
-                               (rc, crm_command, stdout, stderr))
+            daemon_log.warning(
+                "rc=%s running '%s': '%s' '%s'" % (rc, crm_command, stdout, stderr)
+            )
             stdout = None
 
         return stdout
@@ -117,9 +127,9 @@ class CorosyncPlugin(DevicePlugin):
 
         raw_output = self._read_crm_mon_as_xml()
         if raw_output:
-            result['crm_info'] = self._parse_crm_as_xml(raw_output)
+            result["crm_info"] = self._parse_crm_as_xml(raw_output)
         else:
-            result['crm_info'] = None
+            result["crm_info"] = None
 
         result["state"] = {}
         result["state"]["corosync"] = "started" if corosync_running() else "stopped"
@@ -131,6 +141,6 @@ class CorosyncPlugin(DevicePlugin):
         self._reset_delta()
         return self.update_session()
 
-    @exceptionSandBox(daemon_log, ['state', 'nodes'])
+    @exceptionSandBox(daemon_log, ["state", "nodes"])
     def update_session(self):
         return self._delta_result(self._scan())

--- a/chroma_agent/device_plugins/linux_network.py
+++ b/chroma_agent/device_plugins/linux_network.py
@@ -13,31 +13,33 @@ from chroma_agent.log import daemon_log
 from chroma_agent.plugin_manager import DevicePlugin
 
 
-EXCLUDE_INTERFACES = ['lo']
+EXCLUDE_INTERFACES = ["lo"]
 
 
 class NetworkInterface(object):
-    ''' Created with an array of lines that are the output from ifconfig, this class will
+    """ Created with an array of lines that are the output from ifconfig, this class will
     parse those lines and end up with a set of properties corresponding to the parsed data
 
     It only produces what is there and so some values may be left unset. The idea is that
     once parsed the results can be accessed using named properties.
-    '''
+    """
 
-    RXTXStats = namedtuple('RXTXStats', ['rx_bytes', 'tx_bytes'])
+    RXTXStats = namedtuple("RXTXStats", ["rx_bytes", "tx_bytes"])
 
     def __init__(self, ip_output_lines, rx_tx_stats):
-        match_values = ['([0-9]*):(\s*)(?P<interface>[^:]*).*',
-                        '(.*)link/(?P<type>[^\s]*)(\s*)(?P<mac_address>[^\s]*).*',
-                        '(.*)inet (?P<inet4_addr>[^/]*)/(?P<inet4_prefix>[0-9]*).*',
-                        '(.*)inet6 (?P<inet6_addr>[^/]*)/(?P<inet6_mask>[0-9]*).*',
-                        '.*(?P<slave>SLAVE).*',
-                        '.*(?P<up>UP).*']
+        match_values = [
+            "([0-9]*):(\s*)(?P<interface>[^:]*).*",
+            "(.*)link/(?P<type>[^\s]*)(\s*)(?P<mac_address>[^\s]*).*",
+            "(.*)inet (?P<inet4_addr>[^/]*)/(?P<inet4_prefix>[0-9]*).*",
+            "(.*)inet6 (?P<inet6_addr>[^/]*)/(?P<inet6_mask>[0-9]*).*",
+            ".*(?P<slave>SLAVE).*",
+            ".*(?P<up>UP).*",
+        ]
 
-        self._values = defaultdict(lambda: '')
+        self._values = defaultdict(lambda: "")
 
         # Set some defaults
-        self._values['up'] = 'DOWN'
+        self._values["up"] = "DOWN"
 
         for line in ip_output_lines:
             for match_value in match_values:
@@ -48,41 +50,41 @@ class NetworkInterface(object):
         try:
             self.rx_tx_stats = rx_tx_stats[self.interface]
         except KeyError:
-            self.rx_tx_stats = self.RXTXStats('0', '0')
+            self.rx_tx_stats = self.RXTXStats("0", "0")
 
     @property
     def interface(self):
-        '''
+        """
         :return: str: The name of the device, for example eth0 or ib2, or '' if not present.
-        '''
+        """
         return self._values["interface"]
 
     @property
     def mac_address(self):
-        '''
+        """
         :return: str: Containing the mac address of the device, or '' if not present.
-        '''
+        """
         return self._values["mac_address"]
 
     @property
     def type(self):
-        '''
+        """
         :return: str: Containing the type of the interface, ethernet for example, or '' if not present.
-        '''
+        """
         return self._values["type"]
 
     @property
     def inet4_addr(self):
-        '''
+        """
         :return: str: Containing the type of the inet4 address of interface, or '' if not present.
-        '''
+        """
         return self._values["inet4_addr"]
 
     @property
     def inet4_prefix(self):
-        '''
+        """
         :return: int: prefix len converted from the mask described by ifconfig as a slave device. Returns 32 if no prefix existed.
-        '''
+        """
         try:
             return int(self._values["inet4_prefix"])
         except ValueError:
@@ -90,30 +92,28 @@ class NetworkInterface(object):
 
     @property
     def inet6_addr(self):
-        '''
+        """
         :return: str: Containing the type of the inet6 address of interface, or '' if not present.
-        '''
+        """
         return self._values["inet6_addr"]
 
     @property
     def up(self):
-        '''
+        """
         :return: bool: True if the device described as being by ifconfig as being in the up state
-        '''
-        return self._values["up"].upper() == 'UP'
+        """
+        return self._values["up"].upper() == "UP"
 
     @property
     def slave(self):
-        '''
+        """
         :return: bool: True if the device described by ifconfig as a slave device
-        '''
-        return self._values["slave"].upper() == 'SLAVE'
+        """
+        return self._values["slave"].upper() == "SLAVE"
 
 
 class NetworkInterfaces(dict):
-    network_translation = {'ethernet': 'tcp',
-                           'ether': 'tcp',
-                           'infiniband': 'o2ib'}
+    network_translation = {"ethernet": "tcp", "ether": "tcp", "infiniband": "o2ib"}
 
     proc_net_dev_keys = {}
 
@@ -121,23 +121,24 @@ class NetworkInterfaces(dict):
         pass
 
     def __init__(self):
-        '''
+        """
         :return: A dist of dicts that describe all of the network interfaces on the node with
         the exception of the the lo interface which is excluded from the list.
-        '''
+        """
+
         def interface_to_lnet_type(if_type):
-            '''
+            """
             To keep everything consistant we report networks types as the lnd name not the linux name we
             have to translate somewhere so do it at source, if the user ever needs to see it as Linux types
             we can translate back.
             There is a train of thought that says it if is unknown we should cause an exception which means
             the app will not work, I prefer to try an approach that says returning just the unknown might
             well work, and if not it causes an exception somewhere else.
-            '''
+            """
             return self.network_translation.get(if_type.lower(), if_type.lower())
 
         try:
-            ip_out = AgentShell.try_run(['ip', 'addr'])
+            ip_out = AgentShell.try_run(["ip", "addr"])
 
             with open("/proc/net/dev") as file:
                 dev_stats = file.readlines()
@@ -149,7 +150,7 @@ class NetworkInterfaces(dict):
         device_lines = []
         devices = [device_lines]
         for line in ip_out.split("\n"):
-            if line and line[0] != ' ':                                      # First line of a new device.
+            if line and line[0] != " ":  # First line of a new device.
                 if device_lines:
                     device_lines = []
                     devices.append(device_lines)
@@ -168,65 +169,80 @@ class NetworkInterfaces(dict):
             keys = keys[1:]
 
             for index in range(0, len(keys)):
-                NetworkInterfaces.proc_net_dev_keys[("rx_" if index < len(keys) / 2 else "tx_") + keys[index]] = index + 1
+                NetworkInterfaces.proc_net_dev_keys[
+                    ("rx_" if index < len(keys) / 2 else "tx_") + keys[index]
+                ] = (index + 1)
 
         proc_net_dev_values = {}
 
         # Data is on the 3rd line to the end, so get the values for each entry.
         for line in dev_stats[2:]:
             values = line.split()
-            proc_net_dev_values[values[0][:-1]] = NetworkInterface.RXTXStats(values[NetworkInterfaces.proc_net_dev_keys['rx_bytes']],
-                                                                          values[NetworkInterfaces.proc_net_dev_keys['tx_bytes']])
+            proc_net_dev_values[values[0][:-1]] = NetworkInterface.RXTXStats(
+                values[NetworkInterfaces.proc_net_dev_keys["rx_bytes"]],
+                values[NetworkInterfaces.proc_net_dev_keys["tx_bytes"]],
+            )
 
         # Now create a network interface for each of the entries.
         for device_lines in devices:
             interface = NetworkInterface(device_lines, proc_net_dev_values)
 
-            if (interface.interface not in EXCLUDE_INTERFACES) and (interface.slave == False):
-                self[interface.interface] = {'mac_address': interface.mac_address,
-                                             'inet4_address': interface.inet4_addr,
-                                             'inet4_prefix': interface.inet4_prefix,
-                                             'inet6_address': interface.inet6_addr,
-                                             'type': interface_to_lnet_type(interface.type),
-                                             'rx_bytes': interface.rx_tx_stats.rx_bytes,
-                                             'tx_bytes': interface.rx_tx_stats.tx_bytes,
-                                             'up': interface.up,
-                                             'slave': interface.slave}
+            if (interface.interface not in EXCLUDE_INTERFACES) and (
+                interface.slave == False
+            ):
+                self[interface.interface] = {
+                    "mac_address": interface.mac_address,
+                    "inet4_address": interface.inet4_addr,
+                    "inet4_prefix": interface.inet4_prefix,
+                    "inet6_address": interface.inet6_addr,
+                    "type": interface_to_lnet_type(interface.type),
+                    "rx_bytes": interface.rx_tx_stats.rx_bytes,
+                    "tx_bytes": interface.rx_tx_stats.tx_bytes,
+                    "up": interface.up,
+                    "slave": interface.slave,
+                }
 
     def name(self, inet4_address):
         result = None
 
-        if inet4_address == '0':
-            result = 'lo'
+        if inet4_address == "0":
+            result = "lo"
         else:
             for name, interface in self.iteritems():
-                if (interface['inet4_address'] == inet4_address):
+                if interface["inet4_address"] == inet4_address:
                     result = name
                     break
 
         if result == None:
-            raise self.InterfaceNotFound("Unable to find a name for the network address %s" % inet4_address)
+            raise self.InterfaceNotFound(
+                "Unable to find a name for the network address %s" % inet4_address
+            )
 
         return result
 
 
-class LNetNid():
-    ''' Created with a single line that is the output of /proc/sys/lnet/nis, this class will
+class LNetNid:
+    """ Created with a single line that is the output of /proc/sys/lnet/nis, this class will
     parse those lines and end up with a set of properties corresponding to the parsed data
 
     It also requires a list of the network interfaces on the node so that it can name the nids
     with the interface name (eth0) for example. This name is required as it is more stable than
     the network address.
-    '''
+    """
+
     def __init__(self, lnet_nis_line, interfaces):
         tokens = lnet_nis_line.split()
 
-        assert(len(tokens) == 9)
+        assert len(tokens) == 9
 
-        self.nid_address = tokens[0].split("@")[0]  # TODO: Need to convert to an interface
+        self.nid_address = tokens[0].split("@")[
+            0
+        ]  # TODO: Need to convert to an interface
         type_network_no = tokens[0].split("@")[1]
 
-        m = re.match('(\w+?)(\d+)?$', type_network_no)   # Non word, then optional greedy number at end of line.
+        m = re.match(
+            "(\w+?)(\d+)?$", type_network_no
+        )  # Non word, then optional greedy number at end of line.
         self.lnd_type = m.group(1)
         self.lnd_network = m.group(2)
         if not self.lnd_network:
@@ -262,10 +278,10 @@ class LinuxNetworkDevicePlugin(DevicePlugin):
         super(LinuxNetworkDevicePlugin, self).__init__(session)
 
     def _lnet_devices(self, interfaces):
-        '''
+        """
         :param interfaces: A list of the interfaces on the current node
         :return: Returns a dict of dicts describing the nids on the current node.
-        '''
+        """
         # Read active NIDs from /proc
         try:
             with open("/proc/sys/lnet/nis") as file:
@@ -289,16 +305,18 @@ class LinuxNetworkDevicePlugin(DevicePlugin):
 
         for lnet_nid in lnet_nids:
             if lnet_nid.lnd_type not in EXCLUDE_INTERFACES:
-                result[lnet_nid.name] = {'nid_address': lnet_nid.nid_address,
-                                         'lnd_type': lnet_nid.lnd_type,
-                                         'lnd_network': lnet_nid.lnd_network}
+                result[lnet_nid.name] = {
+                    "nid_address": lnet_nid.nid_address,
+                    "lnd_type": lnet_nid.lnd_type,
+                    "lnd_network": lnet_nid.lnd_network,
+                }
 
-            LinuxNetworkDevicePlugin.cache_results(raw_result = result)
+            LinuxNetworkDevicePlugin.cache_results(raw_result=result)
 
         return result
 
     @classmethod
-    def cache_results(cls, raw_result = None, lnet_configuration = None):
+    def cache_results(cls, raw_result=None, lnet_configuration=None):
         assert (raw_result == None) or (lnet_configuration == None)
 
         if lnet_configuration:
@@ -306,32 +324,39 @@ class LinuxNetworkDevicePlugin(DevicePlugin):
 
             interfaces = NetworkInterfaces()
 
-            for network_interface in lnet_configuration['network_interfaces']:
-                raw_result[interfaces.name(network_interface[0])] = {'nid_address': network_interface[0],
-                                                                     'lnd_type': network_interface[1],
-                                                                     'lnd_network': network_interface[2]}
+            for network_interface in lnet_configuration["network_interfaces"]:
+                raw_result[interfaces.name(network_interface[0])] = {
+                    "nid_address": network_interface[0],
+                    "lnd_type": network_interface[1],
+                    "lnd_network": network_interface[2],
+                }
 
         cls.cached_results = raw_result
 
     def _lnet_state(self):
         lnet_up = False
-        lnet_loaded = not bool(AgentShell.run(['udevadm', 'info', '--path', '/sys/module/lnet']).rc)
-        
-        if lnet_loaded:
-            lnet_up = not bool(AgentShell.run(['lnetctl', 'net', 'show']).rc)
+        lnet_loaded = not bool(
+            AgentShell.run(["udevadm", "info", "--path", "/sys/module/lnet"]).rc
+        )
 
-        return {(False, False): "lnet_unloaded",
-                 (False, True): "lnet_unloaded",
-                 (True, False): "lnet_down",
-                 (True, True): "lnet_up"}[(lnet_loaded, lnet_up)]
+        if lnet_loaded:
+            lnet_up = not bool(AgentShell.run(["lnetctl", "net", "show"]).rc)
+
+        return {
+            (False, False): "lnet_unloaded",
+            (False, True): "lnet_unloaded",
+            (True, False): "lnet_down",
+            (True, True): "lnet_up",
+        }[(lnet_loaded, lnet_up)]
 
     def start_session(self):
         interfaces = NetworkInterfaces()
         nids = self._lnet_devices(interfaces)
 
-        result = {'interfaces': interfaces,
-                  'lnet': {'state': self._lnet_state(),
-                           'nids': nids}}
+        result = {
+            "interfaces": interfaces,
+            "lnet": {"state": self._lnet_state(), "nids": nids},
+        }
 
         return result
 

--- a/chroma_agent/device_plugins/lustre.py
+++ b/chroma_agent/device_plugins/lustre.py
@@ -27,31 +27,27 @@ from iml_common.blockdevices.blockdevice import BlockDevice
 from chroma_agent.device_plugins.audit import local
 
 
-VersionInfo = namedtuple('VersionInfo', ['epoch', 'version', 'release', 'arch'])
+VersionInfo = namedtuple("VersionInfo", ["epoch", "version", "release", "arch"])
+
 
 def process_zfs_mount(device, data, zfs_mounts):
     # If zfs-backed target/dataset, lookup underlying pool to get uuid
     # and nested dataset in zed structures to access lustre svname (label).
-    dev_root = device.split('/')[0]
+    dev_root = device.split("/")[0]
     if dev_root not in [d for d, _, _ in zfs_mounts]:
-        daemon_log.debug('lustre device is not zfs')
+        daemon_log.debug("lustre device is not zfs")
         return None, None
 
-    pool = next(
-        p for p in data['zed'].values()
-        if p['name'] == dev_root
-    )
-    dataset = next(
-        d for d in pool['datasets']
-        if d['name'] == device
-    )
+    pool = next(p for p in data["zed"].values() if p["name"] == dev_root)
+    dataset = next(d for d in pool["datasets"] if d["name"] == device)
 
     fs_label = next(
-        p['value'] for p in dataset['props']
-        if p['name'] == 'lustre:svname'  # used to be fsname
+        p["value"]
+        for p in dataset["props"]
+        if p["name"] == "lustre:svname"  # used to be fsname
     )
 
-    fs_uuid = dataset['guid']
+    fs_uuid = dataset["guid"]
 
     return fs_label, fs_uuid
 
@@ -59,14 +55,15 @@ def process_zfs_mount(device, data, zfs_mounts):
 def process_lvm_mount(device, data):
     try:
         bdev = next(
-            (v['paths'], v['lvUuid']) for v in data['blockDevices'].itervalues()
-            if device in v['paths'] and v.get('lvUuid')
+            (v["paths"], v["lvUuid"])
+            for v in data["blockDevices"].itervalues()
+            if device in v["paths"] and v.get("lvUuid")
         )
     except StopIteration:
-        daemon_log.debug('lustre device is not lvm')
+        daemon_log.debug("lustre device is not lvm")
         return None, None
 
-    label_prefix = '/dev/disk/by-label/'
+    label_prefix = "/dev/disk/by-label/"
     fs_label = next(
         p.split(label_prefix, 1)[1] for p in bdev[0] if p.startswith(label_prefix)
     )
@@ -75,7 +72,7 @@ def process_lvm_mount(device, data):
 
 
 class LustrePlugin(DevicePlugin):
-    delta_fields = ['capabilities', 'properties', 'mounts', 'resource_locations']
+    delta_fields = ["capabilities", "properties", "mounts", "resource_locations"]
 
     def __init__(self, session):
         self.reset_state()
@@ -89,9 +86,9 @@ class LustrePlugin(DevicePlugin):
         mounts = {}
 
         data = scanner_cmd("Stream")
-        local_mounts = parse_local_mounts(data['localMounts'])
-        zfs_mounts = [(d, m, f) for d, m, f in local_mounts if f == 'zfs']
-        lustre_mounts = [(d, m, f) for d, m, f in local_mounts if f == 'lustre']
+        local_mounts = parse_local_mounts(data["localMounts"])
+        zfs_mounts = [(d, m, f) for d, m, f in local_mounts if f == "zfs"]
+        lustre_mounts = [(d, m, f) for d, m, f in local_mounts if f == "lustre"]
 
         for device, mntpnt, _ in lustre_mounts:
             fs_label, fs_uuid = process_zfs_mount(device, data, zfs_mounts)
@@ -104,8 +101,8 @@ class LustrePlugin(DevicePlugin):
                     # Assume that while a filesystem is mounted, its UUID and LABEL don't change.
                     # Therefore we can avoid repeated blkid calls with a little caching.
                     if device in self._mount_cache:
-                        fs_uuid = self._mount_cache[device]['fs_uuid']
-                        fs_label = self._mount_cache[device]['fs_label']
+                        fs_uuid = self._mount_cache[device]["fs_uuid"]
+                        fs_label = self._mount_cache[device]["fs_label"]
                     else:
                         # Sending none as the type means BlockDevice will use it's local cache to work the type.
                         # This is not a good method, and we should work on a way of not storing such state but for the
@@ -116,14 +113,16 @@ class LustrePlugin(DevicePlugin):
 
                             # If we have scanned the devices then it is safe to cache the values.
                             if LinuxDevicePlugin.devices_scanned:
-                                self._mount_cache[device]['fs_uuid'] = fs_uuid
-                                self._mount_cache[device]['fs_label'] = fs_label
+                                self._mount_cache[device]["fs_uuid"] = fs_uuid
+                                self._mount_cache[device]["fs_label"] = fs_label
                         except AgentShell.CommandExecutionError:
                             continue
 
             recovery_status = {}
             try:
-                recovery_file = glob.glob("/proc/fs/lustre/*/%s/recovery_status" % fs_label)[0]
+                recovery_file = glob.glob(
+                    "/proc/fs/lustre/*/%s/recovery_status" % fs_label
+                )[0]
                 recovery_status_text = open(recovery_file).read()
                 for line in recovery_status_text.split("\n"):
                     tokens = line.split(":")
@@ -138,9 +137,9 @@ class LustrePlugin(DevicePlugin):
                 pass
 
             mounts[device] = {
-                'fs_uuid': fs_uuid,
-                'mount_point': mntpnt,
-                'recovery_status': recovery_status
+                "fs_uuid": fs_uuid,
+                "mount_point": mntpnt,
+                "recovery_status": recovery_status,
             }
 
         # Drop cached info about anything that is no longer mounted
@@ -157,6 +156,7 @@ class LustrePlugin(DevicePlugin):
         # Only set resource_locations if we have the management package
         try:
             from chroma_agent.action_plugins import manage_targets
+
             resource_locations = manage_targets.get_resource_locations()
         except ImportError:
             resource_locations = None
@@ -172,7 +172,7 @@ class LustrePlugin(DevicePlugin):
             "metrics": audit.metrics(),
             "properties": audit.properties(),
             "mounts": mounts,
-            "resource_locations": resource_locations
+            "resource_locations": resource_locations,
         }
 
     def start_session(self):

--- a/chroma_agent/device_plugins/systemd_journal.py
+++ b/chroma_agent/device_plugins/systemd_journal.py
@@ -6,7 +6,11 @@
 import Queue
 import threading
 from chroma_agent.log import console_log
-from chroma_agent.plugin_manager import DevicePlugin, DevicePluginMessageCollection, PRIO_LOW
+from chroma_agent.plugin_manager import (
+    DevicePlugin,
+    DevicePluginMessageCollection,
+    PRIO_LOW,
+)
 
 import datetime
 import pytz
@@ -31,14 +35,18 @@ def parse_journal(data):
        forwarding protocol is being used.
     """
 
-    utc_dt = get_localzone().localize(data['__REALTIME_TIMESTAMP'], is_dst=None).astimezone(pytz.utc)
+    utc_dt = (
+        get_localzone()
+        .localize(data["__REALTIME_TIMESTAMP"], is_dst=None)
+        .astimezone(pytz.utc)
+    )
 
     return {
-        'datetime': datetime.datetime.isoformat(utc_dt),
-        'severity': data['PRIORITY'],
-        'facility': data.get('SYSLOG_FACILITY', 3),
-        'source': data.get('SYSLOG_IDENTIFIER', 'unknown'),
-        'message': data['MESSAGE']
+        "datetime": datetime.datetime.isoformat(utc_dt),
+        "severity": data["PRIORITY"],
+        "facility": data.get("SYSLOG_FACILITY", 3),
+        "source": data.get("SYSLOG_IDENTIFIER", "unknown"),
+        "message": data["MESSAGE"],
     }
 
 
@@ -53,7 +61,7 @@ class SystemdJournalListener(threading.Thread):
         while self.should_run:
             if j.wait(1) == systemd.journal.APPEND:
                 for entry in j:
-                     _queue.put(parse_journal(entry))
+                    _queue.put(parse_journal(entry))
 
     def stop(self):
         console_log.debug("SystemdJournalListener.stop")
@@ -80,17 +88,20 @@ class SystemdJournalDevicePlugin(DevicePlugin):
         return self.update_session()
 
     def update_session(self):
-        messages = DevicePluginMessageCollection([], priority = PRIO_LOW)
+        messages = DevicePluginMessageCollection([], priority=PRIO_LOW)
         total_lines = 0
         while True:
             lines = self.poll()
             if lines:
                 total_lines += len(lines)
-                messages.append({'log_lines': lines})
+                messages.append({"log_lines": lines})
             else:
                 break
 
-        console_log.debug("SystemdJournalDevicePlugin: %s lines in %s messages" % (total_lines, len(messages)))
+        console_log.debug(
+            "SystemdJournalDevicePlugin: %s lines in %s messages"
+            % (total_lines, len(messages))
+        )
 
         if messages:
             return messages

--- a/chroma_agent/fence_chroma.py
+++ b/chroma_agent/fence_chroma.py
@@ -44,21 +44,35 @@ Arguments read from standard input take the form of:
 
   action                Action to perform (%s)
   port                  Name of node on which to perform action
-""" % ", ".join(VALID_ACTIONS)
+""" % ", ".join(
+        VALID_ACTIONS
+    )
 
-    parser = ArgumentParser(description="Chroma Fence Agent",
-                            formatter_class=RawDescriptionHelpFormatter,
-                            epilog=epilog)
+    parser = ArgumentParser(
+        description="Chroma Fence Agent",
+        formatter_class=RawDescriptionHelpFormatter,
+        epilog=epilog,
+    )
 
-    parser.add_argument("-o", "--option", "--action", dest="action", choices=VALID_ACTIONS)
-    parser.add_argument("-n", "--plug", "--nodename", "--port", dest="port", help="Name of node on which to perform action")
+    parser.add_argument(
+        "-o", "--option", "--action", dest="action", choices=VALID_ACTIONS
+    )
+    parser.add_argument(
+        "-n",
+        "--plug",
+        "--nodename",
+        "--port",
+        dest="port",
+        help="Name of node on which to perform action",
+    )
     ns = parser.parse_args(args)
 
     if not ns.action and not ns.port:
         ns = parser.parse_args(stdin_to_args())
 
     if ns.action == "metadata":
-        print """<?xml version="1.0" ?>
+        print(
+            """<?xml version="1.0" ?>
 <resource-agent name="fence_chroma" shortdesc="Fence agent for Integrated Manager for Lustre software Storage Servers">
 <longdesc>fence_chroma is an I/O Fencing agent which can be used with Integrated Manager for Lustre software Storage Servers.</longdesc>
 <vendor-url>http://www.whamcloud.com</vendor-url>
@@ -83,7 +97,9 @@ Arguments read from standard input take the form of:
     <action name="monitor" />
 </actions>
 </resource-agent>
-""" % ", ".join(VALID_ACTIONS)
+"""
+            % ", ".join(VALID_ACTIONS)
+        )
     elif ns.action in ["on", "off"]:
         node = PacemakerConfig().get_node(ns.port)
         getattr(node, "fence_%s" % ns.action)()
@@ -91,7 +107,7 @@ Arguments read from standard input take the form of:
         manage_node.stonith(ns.port)
     elif ns.action == "list":
         for node in PacemakerConfig().fenceable_nodes:
-            print "%s," % node.name
+            print("%s," % node.name)
     elif ns.action == "monitor":
         # TODO: What does "monitor" mean for this agent? We have to have it
         # to keep pacemaker happy, but longer-term it might make sense to

--- a/chroma_agent/lib/agent_startup_functions.py
+++ b/chroma_agent/lib/agent_startup_functions.py
@@ -16,6 +16,7 @@ def agent_daemon_startup_function():
             ...
 
     """
+
     def _decorator(func):
         agent_daemon_startup_functions.append(func)
         return func

--- a/chroma_agent/lib/agent_teardown_functions.py
+++ b/chroma_agent/lib/agent_teardown_functions.py
@@ -11,6 +11,7 @@ def agent_daemon_teardown_function():
     A decorator for connecting method to teardown. A method decorated with this will be called each time the
     daemon is terminated normally.
     """
+
     def _decorator(func):
         agent_daemon_teardown_functions.append(func)
         return func

--- a/chroma_agent/lib/corosync.py
+++ b/chroma_agent/lib/corosync.py
@@ -21,7 +21,7 @@ from iml_common.lib.service_control import ServiceControl
 from chroma_agent.lib import networking
 from chroma_agent.lib.talker_thread import TalkerThread
 
-env = Environment(loader=PackageLoader('chroma_agent', 'templates'))
+env = Environment(loader=PackageLoader("chroma_agent", "templates"))
 
 firewall_control = FirewallControl.create(logger=console_log)
 
@@ -35,9 +35,10 @@ class RingDetectionError(Exception):
 
 def get_all_interfaces():
     import ethtool
+
     # Not sure how robust this will be; need to test with real gear.
     # In theory, should do the job to exclude IPoIB and lo interfaces.
-    hwaddr_blacklist = ['00:00:00:00:00:00', '80:00:00:48:fe:80']
+    hwaddr_blacklist = ["00:00:00:00:00:00", "80:00:00:48:fe:80"]
     eth_interfaces = []
     for device in ethtool.get_devices():
         if ethtool.get_hwaddr(device) not in hwaddr_blacklist:
@@ -49,9 +50,12 @@ def get_all_interfaces():
 def generate_ring1_network(ring0):
     # find a good place for the ring1 network
     subnet = find_subnet(ring0.ipv4_network, ring0.ipv4_prefixlen)
-    address = str(IPAddress((int(IPAddress(ring0.ipv4_hostmask)) &
-                             int(IPAddress(ring0.ipv4_address))) |
-                            int(subnet.ip)))
+    address = str(
+        IPAddress(
+            (int(IPAddress(ring0.ipv4_hostmask)) & int(IPAddress(ring0.ipv4_address)))
+            | int(subnet.ip)
+        )
+    )
     console_log.info("Chose %s/%d for ring1 address" % (address, subnet.prefixlen))
     return address, str(subnet.prefixlen)
 
@@ -59,10 +63,11 @@ def generate_ring1_network(ring0):
 def get_ring0():
     # ring0 will always be on the interface used for agent->manager comms
     from urlparse import urlparse
+
     server_url = urljoin(os.environ["IML_MANAGER_URL"], "agent")
     manager_address = socket.gethostbyname(urlparse(server_url).hostname)
-    out = AgentShell.try_run(['/sbin/ip', 'route', 'get', manager_address])
-    match = re.search(r'dev\s+([^\s]+)', out)
+    out = AgentShell.try_run(["/sbin/ip", "route", "get", manager_address])
+    match = re.search(r"dev\s+([^\s]+)", out)
     if match:
         manager_dev = match.groups()[0]
     else:
@@ -72,8 +77,9 @@ def get_ring0():
     ring0 = CorosyncRingInterface(manager_dev)
 
     if ring0.ipv4_prefixlen < 9:
-        raise RuntimeError("%s subnet is too large (/%s)" %
-                           (ring0.name, ring0.ipv4_prefixlen))
+        raise RuntimeError(
+            "%s subnet is too large (/%s)" % (ring0.name, ring0.ipv4_prefixlen)
+        )
 
     return ring0
 
@@ -82,9 +88,11 @@ def detect_ring1(ring0, ring1_address, ring1_prefix):
     all_interfaces = get_all_interfaces()
 
     if len(all_interfaces) < 2:
-        raise RingDetectionError("Corosync requires at least 2 network interaces, "
-                                 "one of which my be unconfigured and dedicated to HA monitoring."
-                                 "Only %s interfaces found" % len(all_interfaces))
+        raise RingDetectionError(
+            "Corosync requires at least 2 network interaces, "
+            "one of which my be unconfigured and dedicated to HA monitoring."
+            "Only %s interfaces found" % len(all_interfaces)
+        )
 
     ring1_candidates = []
 
@@ -103,8 +111,10 @@ def detect_ring1(ring0, ring1_address, ring1_prefix):
         console_log.info("Chose %s for corosync ring1" % iface.name)
         iface.set_address(ring1_address, ring1_prefix)
     elif len(ring1_candidates) > 1:
-        raise RingDetectionError("Unable to autodetect ring1: found %d unconfigured interfaces with link" %
-                                 len(ring1_candidates))
+        raise RingDetectionError(
+            "Unable to autodetect ring1: found %d unconfigured interfaces with link"
+            % len(ring1_candidates)
+        )
 
     # Now, go back and look through the list of all interfaces again for
     # our ring1 address. We do it this way in order to handle the situation
@@ -125,7 +135,7 @@ def detect_ring1(ring0, ring1_address, ring1_prefix):
         console_log.info("Proposing %d for multicast port" % iface.mcastport)
 
         # Now see if one is being used on ring1
-        discover_existing_mcastport(iface, timeout = 30)
+        discover_existing_mcastport(iface, timeout=30)
         console_log.info("Decided on %d for multicast port" % iface.mcastport)
 
         return iface
@@ -163,15 +173,21 @@ def find_unused_port(ring0, timeout=10, batch_count=10000):
     ports = range(port_min, port_max, 2)
     portrange_str = "%s-%s" % (port_min, port_max)
 
-    firewall_control.add_rule(0, 'tcp', 'find unused port', persist=False, address=ring0.mcastaddr)
+    firewall_control.add_rule(
+        0, "tcp", "find unused port", persist=False, address=ring0.mcastaddr
+    )
 
     try:
         networking.subscribe_multicast(ring0)
-        console_log.info("Sniffing for packets to %s on %s within port range %s" % (dest_addr,
-                                                                                    ring0.name,
-                                                                                    portrange_str))
-        cap = networking.start_cap(ring0, timeout, "host %s and udp and portrange %s" % (dest_addr,
-                                                                                         portrange_str))
+        console_log.info(
+            "Sniffing for packets to %s on %s within port range %s"
+            % (dest_addr, ring0.name, portrange_str)
+        )
+        cap = networking.start_cap(
+            ring0,
+            timeout,
+            "host %s and udp and portrange %s" % (dest_addr, portrange_str),
+        )
 
         def recv_packets(header, data):
             tgt_port = networking.get_dport_from_packet(data)
@@ -187,19 +203,23 @@ def find_unused_port(ring0, timeout=10, batch_count=10000):
         while time.time() - start < timeout:
             try:
                 packet_count += cap.dispatch(batch_count, recv_packets)
-            except Exception, e:
+            except Exception as e:
                 raise RuntimeError("Error reading from the network: %s" % str(e))
 
-        console_log.info("Finished after %d seconds, sniffed: %d" % (time.time() - start, packet_count))
+        console_log.info(
+            "Finished after %d seconds, sniffed: %d"
+            % (time.time() - start, packet_count)
+        )
     finally:
-        firewall_control.remove_rule(0, 'tcp', 'find unused port', persist=False,
-                                     address=ring0.mcastaddr)
+        firewall_control.remove_rule(
+            0, "tcp", "find unused port", persist=False, address=ring0.mcastaddr
+        )
 
     return choice(ports)
 
 
 def _corosync_listener(service, action):
-    if service == 'corosync' and action == ServiceControl.ServiceState.SERVICESTARTED:
+    if service == "corosync" and action == ServiceControl.ServiceState.SERVICESTARTED:
         console_log.debug("Corosync has been started by this node")
         _stop_talker_thread()
 
@@ -211,7 +231,7 @@ def _start_talker_thread(interface):
         console_log.debug("Starting talker thread")
         talker_thread = TalkerThread(interface, console_log)
         talker_thread.start()
-        ServiceControl.register_listener('corosync', _corosync_listener)
+        ServiceControl.register_listener("corosync", _corosync_listener)
 
 
 def _stop_talker_thread():
@@ -221,19 +241,26 @@ def _stop_talker_thread():
         console_log.debug("Stopping talker thread")
         talker_thread.stop()
         talker_thread = None
-        ServiceControl.unregister_listener('corosync', _corosync_listener)
+        ServiceControl.unregister_listener("corosync", _corosync_listener)
 
 
-def discover_existing_mcastport(ring1, timeout = 10):
-    console_log.debug("Sniffing for packets to %s on %s (%s)" % (ring1.mcastaddr, ring1.name, ring1.ipv4_address))
+def discover_existing_mcastport(ring1, timeout=10):
+    console_log.debug(
+        "Sniffing for packets to %s on %s (%s)"
+        % (ring1.mcastaddr, ring1.name, ring1.ipv4_address)
+    )
 
-    console_log.debug("Sniffing for packets to %s on %s" % (ring1.mcastaddr, ring1.name))
+    console_log.debug(
+        "Sniffing for packets to %s on %s" % (ring1.mcastaddr, ring1.name)
+    )
     networking.subscribe_multicast(ring1)
 
-    cap = networking.start_cap(ring1,
-                               timeout / 10,
-                               "ip multicast and dst host %s and not src host %s" % (ring1.mcastaddr,
-                                                                                     ring1.ipv4_address))
+    cap = networking.start_cap(
+        ring1,
+        timeout / 10,
+        "ip multicast and dst host %s and not src host %s"
+        % (ring1.mcastaddr, ring1.ipv4_address),
+    )
 
     # Stop the talker thread if it is running.
     _stop_talker_thread()
@@ -250,15 +277,17 @@ def discover_existing_mcastport(ring1, timeout = 10):
         while packet_count < 1 and time.time() < start_time + timeout:
             try:
                 packet_count += cap.dispatch(1, recv_packets)
-            except Exception, e:
-                raise RuntimeError("Error reading from the network: %s" %
-                                   str(e))
+            except Exception as e:
+                raise RuntimeError("Error reading from the network: %s" % str(e))
 
             # If we haven't seen anything yet, make sure we are blathering...
             if packet_count < 1:
                 _start_talker_thread(ring1)
 
-        console_log.debug("Finished after %d seconds, sniffed: %d" % (time.time() - start_time, packet_count))
+        console_log.debug(
+            "Finished after %d seconds, sniffed: %d"
+            % (time.time() - start_time, packet_count)
+        )
     finally:
         # If we heard someone else talking (ring1_original_mcast_post != ring1.mcast_post)
         # then stop the talker thread, otherwise we should continue to fill the dead air until we start corosync.
@@ -267,7 +296,7 @@ def discover_existing_mcastport(ring1, timeout = 10):
 
 
 def render_config(interfaces):
-    conf_template = env.get_template('corosync.conf')
+    conf_template = env.get_template("corosync.conf")
     return conf_template.render(interfaces=interfaces)
 
 
@@ -281,7 +310,7 @@ def write_config_to_file(path, config):
     os.write(tmpf, config)
     try:
         shutil.move(path, "%s.old" % path)
-    except IOError, e:
+    except IOError as e:
         if e.errno != errno.ENOENT:
             raise e
     os.close(tmpf)
@@ -294,10 +323,25 @@ class CorosyncRingInterface(object):
     Provides a wrapper around an ethtool device with extra functionality
     specific to corosync configuration.
     """
-    IFF_LIST = ['IFF_ALLMULTI', 'IFF_AUTOMEDIA', 'IFF_BROADCAST', 'IFF_DEBUG', 'IFF_DYNAMIC',
-                'IFF_LOOPBACK', 'IFF_MASTER', 'IFF_MULTICAST', 'IFF_NOARP', 'IFF_NOTRAILERS',
-                'IFF_POINTOPOINT', 'IFF_PORTSEL', 'IFF_PROMISC', 'IFF_RUNNING', 'IFF_SLAVE',
-                'IFF_UP']
+
+    IFF_LIST = [
+        "IFF_ALLMULTI",
+        "IFF_AUTOMEDIA",
+        "IFF_BROADCAST",
+        "IFF_DEBUG",
+        "IFF_DYNAMIC",
+        "IFF_LOOPBACK",
+        "IFF_MASTER",
+        "IFF_MULTICAST",
+        "IFF_NOARP",
+        "IFF_NOTRAILERS",
+        "IFF_POINTOPOINT",
+        "IFF_PORTSEL",
+        "IFF_PROMISC",
+        "IFF_RUNNING",
+        "IFF_SLAVE",
+        "IFF_UP",
+    ]
 
     def __init__(self, name, ringnumber=0, mcastport=0):
         # ethtool does NOT like unicode
@@ -310,13 +354,15 @@ class CorosyncRingInterface(object):
         flag = "IFF_%s" % attr[3:].upper()
         if attr.startswith("is_") and flag in self.IFF_LIST:
             import ethtool
+
             return ethtool.get_flags(self.name) & getattr(ethtool, flag) > 0
 
         if hasattr(self._info, attr):
             return getattr(self._info, attr)
         else:
-            raise AttributeError("'%s' object has no attribute '%s'" %
-                                 (self.__class__.__name__, attr))
+            raise AttributeError(
+                "'%s' object has no attribute '%s'" % (self.__class__.__name__, attr)
+            )
 
     def set_address(self, ipv4_address, prefix):
         ifaddr = "%s/%s" % (ipv4_address, prefix)
@@ -324,11 +370,10 @@ class CorosyncRingInterface(object):
         console_log.info("Set %s (%s) up" % (self.name, ifaddr))
 
         if self.ipv4_address != ipv4_address:
-            node_admin.unmanage_network(self.device,
-                                        self.mac_address)
+            node_admin.unmanage_network(self.device, self.mac_address)
 
-            AgentShell.try_run(['/sbin/ip', 'link', 'set', 'dev', self.name, 'up'])
-            AgentShell.try_run(['/sbin/ip', 'addr', 'add', ifaddr, 'dev', self.name])
+            AgentShell.try_run(["/sbin/ip", "link", "set", "dev", self.name, "up"])
+            AgentShell.try_run(["/sbin/ip", "addr", "add", ifaddr, "dev", self.name])
 
             # The link address change is asynchronous, so we need to wait for the
             # address to stick of we have a race condition.
@@ -339,19 +384,27 @@ class CorosyncRingInterface(object):
                 timeout -= 1
 
             if self.ipv4_address != ipv4_address:
-                raise RuntimeError('Unable to set the address %s for interface %s' % (self.ipv4_address, self.name))
+                raise RuntimeError(
+                    "Unable to set the address %s for interface %s"
+                    % (self.ipv4_address, self.name)
+                )
 
-            node_admin.write_ifcfg(self.device, self.mac_address,
-                                   self.ipv4_address, self.ipv4_netmask)
+            node_admin.write_ifcfg(
+                self.device, self.mac_address, self.ipv4_address, self.ipv4_netmask
+            )
         else:
-            console_log.info("Nothing to do as %s already has address %s" % (self.name, ifaddr))
+            console_log.info(
+                "Nothing to do as %s already has address %s" % (self.name, ifaddr)
+            )
 
     def refresh(self):
         import ethtool
+
         self._info = ethtool.get_interfaces_info(self.name)[0]
         try:
-            self._network = IPNetwork("%s/%s" % (self._info.ipv4_address,
-                                                 self._info.ipv4_netmask))
+            self._network = IPNetwork(
+                "%s/%s" % (self._info.ipv4_address, self._info.ipv4_netmask)
+            )
         except (UnboundLocalError, AddrFormatError):
             pass
 
@@ -401,18 +454,18 @@ class CorosyncRingInterface(object):
         time_left = 0
 
         if not self.is_up:
-            AgentShell.try_run(['/sbin/ip', 'link', 'set', 'dev', self.name, 'up'])
+            AgentShell.try_run(["/sbin/ip", "link", "set", "dev", self.name, "up"])
             time_left = 10
 
         def _has_link():
             SIOCETHTOOL = 0x8946
-            ETHTOOL_GLINK = 0x0000000a
+            ETHTOOL_GLINK = 0x0000000A
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            ecmd = array.array('B', struct.pack('2I', ETHTOOL_GLINK, 0))
-            ifreq = struct.pack('16sP', self.name, ecmd.buffer_info()[0])
+            ecmd = array.array("B", struct.pack("2I", ETHTOOL_GLINK, 0))
+            ifreq = struct.pack("16sP", self.name, ecmd.buffer_info()[0])
             fcntl.ioctl(sock.fileno(), SIOCETHTOOL, ifreq)
             sock.close()
-            return bool(struct.unpack('4xI', ecmd.tostring())[0])
+            return bool(struct.unpack("4xI", ecmd.tostring())[0])
 
         try:
             while time_left:
@@ -430,8 +483,10 @@ class CorosyncRingInterface(object):
             return False
         finally:
             if not old_link_state_up:
-                AgentShell.try_run(['/sbin/ip', 'link', 'set', 'dev', self.name, 'down'])
+                AgentShell.try_run(
+                    ["/sbin/ip", "link", "set", "dev", self.name, "down"]
+                )
 
 
 def corosync_running():
-    return ServiceControl.create('corosync').running
+    return ServiceControl.create("corosync").running

--- a/chroma_agent/lib/fence_agents.py
+++ b/chroma_agent/lib/fence_agents.py
@@ -20,50 +20,62 @@ class FenceAgent(object):
         self.base_cmd = base_cmd
 
     def toggle_outlet(self, state):
-        AgentShell.try_run(self.base_cmd + ['-n', self.plug, '-o', state])
+        AgentShell.try_run(self.base_cmd + ["-n", self.plug, "-o", state])
 
     def list(self):
         if platform_info.distro_version >= 7.0:
-            AgentShell.try_run(self.base_cmd + ['-n', self.plug, '-o', 'list-status'])
+            AgentShell.try_run(self.base_cmd + ["-n", self.plug, "-o", "list-status"])
         else:
-            AgentShell.try_run(self.base_cmd + ['-a', 'list'])
+            AgentShell.try_run(self.base_cmd + ["-a", "list"])
 
     def status(self):
-        AgentShell.try_run(self.base_cmd + ['-n', self.plug, '-o', 'status'])
+        AgentShell.try_run(self.base_cmd + ["-n", self.plug, "-o", "status"])
 
     def off(self):
-        self.toggle_outlet('off')
+        self.toggle_outlet("off")
 
     def on(self):
-        self.toggle_outlet('on')
+        self.toggle_outlet("on")
 
     def reboot(self):
-        self.toggle_outlet('reboot')
+        self.toggle_outlet("reboot")
 
 
 class fence_apc(FenceAgent):
     def __init__(self, agent, login, password, ipaddr, plug, ipport=23):
-        super(fence_apc, self).__init__(plug,
-                                        [agent, '-a', ipaddr, '-u', str(ipport), '-l', login, '-p', password])
+        super(fence_apc, self).__init__(
+            plug, [agent, "-a", ipaddr, "-u", str(ipport), "-l", login, "-p", password]
+        )
 
 
 class fence_apc_snmp(FenceAgent):
     def __init__(self, agent, login, password, ipaddr, plug, ipport=161):
-        super(fence_apc_snmp, self).__init__(plug,
-                                             [agent, '-a', ipaddr, '-u', str(ipport), '-l', login, '-p', password])
+        super(fence_apc_snmp, self).__init__(
+            plug, [agent, "-a", ipaddr, "-u", str(ipport), "-l", login, "-p", password]
+        )
 
 
 class fence_virsh(FenceAgent):
-    def __init__(self, agent, login, plug, ipaddr, ipport=22, password=None, identity_file="%s/.ssh/id_rsa" % expanduser("~")):
+    def __init__(
+        self,
+        agent,
+        login,
+        plug,
+        ipaddr,
+        ipport=22,
+        password=None,
+        identity_file="%s/.ssh/id_rsa" % expanduser("~"),
+    ):
         if identity_file and isfile(identity_file):
-            auth = ['-k', identity_file]
+            auth = ["-k", identity_file]
         elif password:
-            auth = ['-p', password]
+            auth = ["-p", password]
         else:
             raise RuntimeError("Neither password nor identity_file were supplied")
 
-        super(fence_virsh, self).__init__(plug,
-                                          [agent, '-a', ipaddr, '-u', str(ipport), '-l', login, '-x'] + auth)
+        super(fence_virsh, self).__init__(
+            plug, [agent, "-a", ipaddr, "-u", str(ipport), "-l", login, "-x"] + auth
+        )
 
     def on(self):
         """Override super.on to wait 15 seconds then process as usual.
@@ -81,16 +93,26 @@ class fence_virsh(FenceAgent):
 
 
 class fence_vbox(FenceAgent):
-    def __init__(self, agent, login, plug, ipaddr, ipport=22, password=None, identity_file="%s/.ssh/id_rsa" % expanduser("~")):
+    def __init__(
+        self,
+        agent,
+        login,
+        plug,
+        ipaddr,
+        ipport=22,
+        password=None,
+        identity_file="%s/.ssh/id_rsa" % expanduser("~"),
+    ):
         if password:
-            auth = ['-p', password]
+            auth = ["-p", password]
         elif identity_file and isfile(identity_file):
-            auth = ['-k', identity_file]
+            auth = ["-k", identity_file]
         else:
             raise RuntimeError("Neither password nor identity_file were supplied")
 
-        super(fence_vbox, self).__init__(plug,
-                                          [agent, '-a', ipaddr, '-u', str(ipport), '-l', login, '-x'] + auth)
+        super(fence_vbox, self).__init__(
+            plug, [agent, "-a", ipaddr, "-u", str(ipport), "-l", login, "-x"] + auth
+        )
 
     def on(self):
         """Override super.on to wait 15 seconds then process as usual.
@@ -110,12 +132,11 @@ class fence_vbox(FenceAgent):
 class fence_ipmilan(FenceAgent):
     def __init__(self, agent, login, password, ipaddr, lanplus=False):
         if lanplus:
-            base_cmd = [agent, '-P', '-a', ipaddr, '-l', login, '-p', password]
+            base_cmd = [agent, "-P", "-a", ipaddr, "-l", login, "-p", password]
         else:
-            base_cmd = [agent, '-a', ipaddr, '-l', login, '-p', password]
+            base_cmd = [agent, "-a", ipaddr, "-l", login, "-p", password]
 
-        super(fence_ipmilan, self).__init__("",
-                                            base_cmd)
+        super(fence_ipmilan, self).__init__("", base_cmd)
 
     def toggle_outlet(self, state):
-        AgentShell.try_run(self.base_cmd + ['-o', state])
+        AgentShell.try_run(self.base_cmd + ["-o", state])

--- a/chroma_agent/lib/networking.py
+++ b/chroma_agent/lib/networking.py
@@ -12,9 +12,10 @@ try:
     import pcapy
 except ImportError:
     import platform
+
     # Maybe OK if we are running on a mac or nosetests because the unittest
     # machines don't have impacket installed.
-    if platform.system() != 'Darwin' and 'nosetests' not in sys.argv[0]:
+    if platform.system() != "Darwin" and "nosetests" not in sys.argv[0]:
         raise
 
 from netaddr import IPNetwork, IPAddress
@@ -30,8 +31,7 @@ def find_subnet(network, prefixlen):
     10.255.255.255/32
     """
     _network = IPNetwork("%s/%s" % (network, prefixlen))
-    if _network >= IPNetwork("10.0.0.0/8") and \
-       _network < IPAddress("10.255.255.255"):
+    if _network >= IPNetwork("10.0.0.0/8") and _network < IPAddress("10.255.255.255"):
         if _network >= IPNetwork("10.128.0.0/9"):
             shadow_network = IPNetwork("10.0.0.0/%s" % prefixlen)
         else:
@@ -46,10 +46,16 @@ def subscribe_multicast(interface):
     """subscribe to the mcast addr"""
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_IF, socket.inet_aton(interface.ipv4_address))
-    mreq = socket.inet_aton(interface.mcastaddr) + socket.inet_aton(interface.ipv4_address)
+    sock.setsockopt(
+        socket.IPPROTO_IP,
+        socket.IP_MULTICAST_IF,
+        socket.inet_aton(interface.ipv4_address),
+    )
+    mreq = socket.inet_aton(interface.mcastaddr) + socket.inet_aton(
+        interface.ipv4_address
+    )
     sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
-    sock.bind(('', 52122))
+    sock.bind(("", 52122))
 
     return sock
 
@@ -58,7 +64,7 @@ def start_cap(interface, timeout, filter):
     try:
         cap = pcapy.open_live(interface.name, 64, True, timeout * 1000)
         cap.setfilter(filter)
-    except Exception, e:
+    except Exception as e:
         raise RuntimeError("Error doing open_live() / setfilter(): %s" % e)
 
     return cap
@@ -69,5 +75,5 @@ def get_dport_from_packet(data):
     try:
         packet = decoder.decode(data)
         return packet.child().child().get_uh_dport()
-    except Exception, e:
+    except Exception as e:
         raise RuntimeError("Error decoding network packet: %s" % str(e))

--- a/chroma_agent/lib/node_admin.py
+++ b/chroma_agent/lib/node_admin.py
@@ -5,19 +5,23 @@ import errno
 from jinja2 import Environment, PackageLoader
 from chroma_agent.lib.shell import AgentShell
 
-env = Environment(loader=PackageLoader('chroma_agent', 'templates'))
+env = Environment(loader=PackageLoader("chroma_agent", "templates"))
 
 NM_STOPPED_RC = 8  # network manager stopped
 
 
 def write_ifcfg(device, mac_address, ipv4_address, ipv4_netmask):
-    ifcfg_tmpl = env.get_template('ifcfg-nic')
+    ifcfg_tmpl = env.get_template("ifcfg-nic")
     ifcfg_path = "/etc/sysconfig/network-scripts/ifcfg-%s" % device
     with open(ifcfg_path, "w") as f:
-        f.write(ifcfg_tmpl.render(device=device,
-                                  mac_address=mac_address,
-                                  ipv4_address=ipv4_address,
-                                  ipv4_netmask=ipv4_netmask))
+        f.write(
+            ifcfg_tmpl.render(
+                device=device,
+                mac_address=mac_address,
+                ipv4_address=ipv4_address,
+                ipv4_netmask=ipv4_netmask,
+            )
+        )
 
     return ifcfg_path
 
@@ -33,7 +37,7 @@ def unmanage_network(device, mac_address):
 
     if ifcfg_path:
         try:
-            AgentShell.try_run(['nmcli', 'con', 'load', ifcfg_path])
+            AgentShell.try_run(["nmcli", "con", "load", ifcfg_path])
         except OSError as e:
             if e.errno != errno.ENOENT:
                 raise e

--- a/chroma_agent/lib/pacemaker.py
+++ b/chroma_agent/lib/pacemaker.py
@@ -31,19 +31,20 @@ class PacemakerObject(object):
         for source in [self.__dict__, self.element.attrib]:
             try:
                 return source[attr]
-            except KeyError, AttributeError:
+            except (KeyError, AttributeError) as _:
                 pass
 
         raise AttributeError(
-            "'%s' has no attribute '%s'" % (self.__class__.__name__, attr))
+            "'%s' has no attribute '%s'" % (self.__class__.__name__, attr)
+        )
 
 
 class LustreTarget(PacemakerObject):
     @property
     def uuid(self):
-        for nvpair in self.element.findall('./instance_attributes/nvpair'):
-            if nvpair.get('name') == "target":
-                return nvpair.get('value')
+        for nvpair in self.element.findall("./instance_attributes/nvpair"):
+            if nvpair.get("name") == "target":
+                return nvpair.get("value")
 
 
 # TODO: Refactor this class to use PacemakerObject
@@ -58,12 +59,12 @@ class PacemakerNode(object):
         self.fence_on()
 
     def fence_off(self):
-        if self.attributes.get('standby', "off") != "on":
+        if self.attributes.get("standby", "off") != "on":
             for agent in self.fence_agents:
                 agent.off()
 
     def fence_on(self):
-        if self.attributes.get('standby', "off") != "on":
+        if self.attributes.get("standby", "off") != "on":
             for agent in self.fence_agents:
                 agent.on()
 
@@ -72,10 +73,9 @@ class PacemakerNode(object):
         agents = []
         for kwargs in self.fence_agent_kwargs:
             try:
-                agents.append(getattr(fence_agents, kwargs['agent'])(**kwargs))
+                agents.append(getattr(fence_agents, kwargs["agent"])(**kwargs))
             except AttributeError:
-                raise PacemakerError(
-                    "No FenceAgent class for %s" % kwargs['agent'])
+                raise PacemakerError("No FenceAgent class for %s" % kwargs["agent"])
         return agents
 
     @property
@@ -84,27 +84,31 @@ class PacemakerNode(object):
         for ad in self.fence_agent_dicts:
             new = {}
             for k, v in ad.items():
-                new[k[k.rfind('fence_') + 6:]] = v
+                new[k[k.rfind("fence_") + 6 :]] = v
             kwargs.append(new)
         return kwargs
 
     @property
     def fence_agent_dicts(self):
         agents = []
-        for agent in [k for k in self.attributes if 'agent' in k]:
-            index = agent[0:agent.find('_')]
+        for agent in [k for k in self.attributes if "agent" in k]:
+            index = agent[0 : agent.find("_")]
             agents.append(
-                dict([
-                    t for t in self.attributes.items()
-                    if t[0].startswith("%s_fence_" % index)
-                ]))
+                dict(
+                    [
+                        t
+                        for t in self.attributes.items()
+                        if t[0].startswith("%s_fence_" % index)
+                    ]
+                )
+            )
 
         return agents
 
     def set_fence_attributes(self, index, attributes):
         # HYD-2014: Make sure we set the N_fence_agent attribute last
         # in order to avoid races.
-        agent = attributes.pop('agent')
+        agent = attributes.pop("agent")
         for key, value in attributes.items():
             self.set_attribute("%s_fence_%s" % (index, key), value)
         self.set_attribute("%s_fence_agent" % index, agent)
@@ -113,7 +117,7 @@ class PacemakerNode(object):
         # HYD-2014: Make sure we remove the N_fence_agent attribute first
         # in order to avoid races.
         for fence_agent in self.fence_agent_dicts:
-            key = [a for a in fence_agent if 'fence_agent' in a][0]
+            key = [a for a in fence_agent if "fence_agent" in a][0]
             del fence_agent[key]
             self.clear_attribute(key)
 
@@ -121,29 +125,55 @@ class PacemakerNode(object):
                 self.clear_attribute(agent_attr)
 
     def enable_standby(self):
-        AgentShell.try_run([
-            "crm_attribute", "-N", self.name, "-n", "standby", "-v", "on",
-            "--lifetime=forever"
-        ])
+        AgentShell.try_run(
+            [
+                "crm_attribute",
+                "-N",
+                self.name,
+                "-n",
+                "standby",
+                "-v",
+                "on",
+                "--lifetime=forever",
+            ]
+        )
 
     def disable_standby(self):
-        AgentShell.try_run([
-            "crm_attribute", "-N", self.name, "-n", "standby", "-v", "off",
-            "--lifetime=forever"
-        ])
+        AgentShell.try_run(
+            [
+                "crm_attribute",
+                "-N",
+                self.name,
+                "-n",
+                "standby",
+                "-v",
+                "off",
+                "--lifetime=forever",
+            ]
+        )
 
     # These crm_attribute options are undocumented, but they're exactly
     # what the crm utility uses when it does its thing. The documented
     # options don't actually work! Fun.
     def set_attribute(self, key, value):
-        AgentShell.try_run([
-            "crm_attribute", "-t", "nodes", "-U", self.name, "-n", key, "-v",
-            str(value)
-        ])
+        AgentShell.try_run(
+            [
+                "crm_attribute",
+                "-t",
+                "nodes",
+                "-U",
+                self.name,
+                "-n",
+                key,
+                "-v",
+                str(value),
+            ]
+        )
 
     def clear_attribute(self, key):
         AgentShell.try_run(
-            ["crm_attribute", "-D", "-t", "nodes", "-U", self.name, "-n", key])
+            ["crm_attribute", "-D", "-t", "nodes", "-U", self.name, "-n", key]
+        )
 
 
 class PacemakerConfig(object):
@@ -176,22 +206,21 @@ class PacemakerConfig(object):
 
     @property
     def configuration(self):
-        return self.root.find('configuration')
+        return self.root.find("configuration")
 
     @property
     def crm_config(self):
-        return self.configuration.find('crm_config')
+        return self.configuration.find("crm_config")
 
     @property
     def nodes(self):
         nodes = []
-        for node in self.configuration.find('nodes'):
-            nodeobj = PacemakerNode(node.get('uname'), node.get('id'))
+        for node in self.configuration.find("nodes"):
+            nodeobj = PacemakerNode(node.get("uname"), node.get("id"))
             try:
-                i_attrs = node.find('instance_attributes')
-                for nvpair in i_attrs.findall('nvpair'):
-                    nodeobj.attributes[nvpair.get('name')] = nvpair.get(
-                        'value')
+                i_attrs = node.find("instance_attributes")
+                for nvpair in i_attrs.findall("nvpair"):
+                    nodeobj.attributes[nvpair.get("name")] = nvpair.get("value")
             except AttributeError:
                 # No instance_attributes
                 pass
@@ -203,19 +232,18 @@ class PacemakerConfig(object):
     def lustre_targets(self):
         targets = []
         for primitive in self.configuration.findall("./resources/primitive"):
-            if primitive.attrib['type'] == "Target":
+            if primitive.attrib["type"] == "Target":
                 targets.append(LustreTarget(primitive))
 
         return targets
 
     @property
     def dc(self):
-        dc_uuid = self.root.get('dc-uuid')
+        dc_uuid = self.root.get("dc-uuid")
 
         if dc_uuid:
             try:
-                return next(
-                    node.name for node in self.nodes if node.uuid == dc_uuid)
+                return next(node.name for node in self.nodes if node.uuid == dc_uuid)
             except StopIteration:
                 pass
 
@@ -228,8 +256,10 @@ class PacemakerConfig(object):
     def get_node(self, node_name):
         try:
             return next(
-                n for n in self.nodes
-                if socket.getfqdn(n.name) == socket.getfqdn(node_name))
+                n
+                for n in self.nodes
+                if socket.getfqdn(n.name) == socket.getfqdn(node_name)
+            )
         except IndexError:
             raise PacemakerError("%s does not exist in pacemaker" % node_name)
 
@@ -239,16 +269,17 @@ class PacemakerConfig(object):
 
     @property
     def configured(self):
-        ''' configured returns True if this node has a pacemaker configuration set by IML.
+        """ configured returns True if this node has a pacemaker configuration set by IML.
         :return: True if configuration present else False
-        '''
-        return 'fence_chroma' in AgentShell.try_run(
-            ['cibadmin', '--query', '-o', 'resource'])
+        """
+        return "fence_chroma" in AgentShell.try_run(
+            ["cibadmin", "--query", "-o", "resource"]
+        )
 
     def get_property_setvalue(self, property_set_name, value_name):
-        '''
+        """
         :return: Value 'value_name' from a property set of name 'property_set_name'. None if no value.
-        '''
+        """
         property_set = self.get_propertyset(property_set_name)
 
         return property_set.get(value_name, None)
@@ -258,27 +289,36 @@ class PacemakerConfig(object):
 
         for key, value in properties.items():
             nvpairs += '<nvpair id="%s-%s" name="%s" value="%s"/>\n' % (
-                propertyset_name, key, key, value)
+                propertyset_name,
+                key,
+                key,
+                value,
+            )
 
-        cibadmin([
-            "--modify", "--allow-create", "-o", "crm_config", "-X",
-            '<cluster_property_set id="%s">\n%s' % (propertyset_name, nvpairs)
-        ])
+        cibadmin(
+            [
+                "--modify",
+                "--allow-create",
+                "-o",
+                "crm_config",
+                "-X",
+                '<cluster_property_set id="%s">\n%s' % (propertyset_name, nvpairs),
+            ]
+        )
 
     def get_propertyset(self, propertyset_name):
         result = {}
 
         for propertyset in self.crm_config:
-            if propertyset.attrib['id'] == propertyset_name:
+            if propertyset.attrib["id"] == propertyset_name:
                 for value_pair in propertyset:
-                    result[value_pair.attrib['name']] = value_pair.attrib[
-                        'value']
+                    result[value_pair.attrib["name"]] = value_pair.attrib["value"]
 
         return result
 
 
 def cibadmin(command_args, timeout=120):
-    assert timeout > 0, 'timeout must be greater than zero'
+    assert timeout > 0, "timeout must be greater than zero"
 
     # I think these are "errno" values, but I'm not positive
     # but going forward, any additions to this should try to be informative
@@ -287,10 +327,10 @@ def cibadmin(command_args, timeout=120):
         10: "something unknown",
         41: "something unknown",
         62: "Timer expired",
-        107: "Transport endpoint is not connected"
+        107: "Transport endpoint is not connected",
     }
 
-    command_args.insert(0, 'cibadmin')
+    command_args.insert(0, "cibadmin")
     # NB: This isn't a "true" timeout, in that it won't forcibly stop the
     # subprocess after a timeout. We'd need more invasive changes to
     # shell._run() for that.
@@ -304,11 +344,12 @@ def cibadmin(command_args, timeout=120):
 
     if result.rc in RETRY_CODES:
         raise PacemakerError(
-            "%s timed out after %d seconds: rc: %s, stderr: %s" %
-            (" ".join(command_args), timeout, result.rc, result.stderr))
+            "%s timed out after %d seconds: rc: %s, stderr: %s"
+            % (" ".join(command_args), timeout, result.rc, result.stderr)
+        )
     else:
         raise AgentShell.CommandExecutionError(result, command_args)
 
 
 def pacemaker_running():
-    return ServiceControl.create('pacemaker').running
+    return ServiceControl.create("pacemaker").running

--- a/chroma_agent/lib/shell.py
+++ b/chroma_agent/lib/shell.py
@@ -11,7 +11,7 @@ import threading
 from iml_common.lib.shell import BaseShell
 from iml_common.lib.shell import set_shell
 
-console_log = logging.getLogger('console')
+console_log = logging.getLogger("console")
 
 
 class ResultStore(threading.local):
@@ -47,12 +47,14 @@ class ResultStore(threading.local):
         :arg result is the RunResult of the command.
         """
         if self._save:
-            self._subprocesses.append({
-                'args': arg_list,
-                'rc': result.rc,
-                'stdout': result.stdout,
-                'stderr': result.stderr
-            })
+            self._subprocesses.append(
+                {
+                    "args": arg_list,
+                    "rc": result.rc,
+                    "stdout": result.stdout,
+                    "stderr": result.stderr,
+                }
+            )
 
 
 class AgentShell(BaseShell):
@@ -69,7 +71,9 @@ class AgentShell(BaseShell):
     def monitor_func(cls, process, arg_list, logger):
         if AgentShell.thread_state.abort.is_set():
             if logger:
-                logger.warning("Teardown: killing subprocess %s (%s)" % (process.pid, arg_list))
+                logger.warning(
+                    "Teardown: killing subprocess %s (%s)" % (process.pid, arg_list)
+                )
             process.kill()
             raise AgentShell.SubprocessAborted()
 
@@ -117,9 +121,15 @@ class AgentShell(BaseShell):
         result = AgentShell.run(arg_list)
 
         if result.rc != 0:
-            return "Error (%s) running '%s': '%s' '%s'" % (result.rc, " ".join(arg_list), result.stdout, result.stderr)
+            return "Error (%s) running '%s': '%s' '%s'" % (
+                result.rc,
+                " ".join(arg_list),
+                result.stdout,
+                result.stderr,
+            )
 
         return None
+
 
 # We want iml_common routines to use our AgentShell.
 set_shell(AgentShell)

--- a/chroma_agent/lib/talker_thread.py
+++ b/chroma_agent/lib/talker_thread.py
@@ -37,6 +37,8 @@ class TalkerThread(threading.Thread):
         sock = networking.subscribe_multicast(self.interface)
 
         while not self._stop.is_set():
-            sock.sendto("%d\n\0" % self.interface.mcastport,
-                        (self.interface.mcastaddr, self.interface.mcastport))
+            sock.sendto(
+                "%d\n\0" % self.interface.mcastport,
+                (self.interface.mcastaddr, self.interface.mcastport),
+            )
             self._stop.wait(0.25)

--- a/chroma_agent/lib/yum_utils.py
+++ b/chroma_agent/lib/yum_utils.py
@@ -6,12 +6,8 @@ from chroma_agent.lib.shell import AgentShell
 from chroma_agent.log import daemon_log
 
 
-def yum_util(action,
-             packages=[],
-             fromrepo=None,
-             enablerepo=None,
-             narrow_updates=False):
-    '''
+def yum_util(action, packages=[], fromrepo=None, enablerepo=None, narrow_updates=False):
+    """
     A wrapper to perform yum actions in encapsulated way.
     :param action:  clean, install, remove, update, requires etc
     :param packages: Packages to install or remove
@@ -19,40 +15,49 @@ def yum_util(action,
     :param enablerepo: The repo to enable for the action, others are not disabled or enabled
     :param narrow_updates: ?
     :return: No return but throws CommandExecutionError on error.
-    '''
+    """
 
     if fromrepo and enablerepo:
-        raise ValueError(
-            "Cannot provide fromrepo and enablerepo simultaneously")
+        raise ValueError("Cannot provide fromrepo and enablerepo simultaneously")
 
     repo_arg = []
     valid_rc_values = [0]  # Some errors values other than 0 are valid.
     tries = 2
     if fromrepo:
-        repo_arg = ['--disablerepo=*'] + ['--enablerepo=%s' % r for r in fromrepo]
+        repo_arg = ["--disablerepo=*"] + ["--enablerepo=%s" % r for r in fromrepo]
     elif enablerepo:
-        repo_arg = ['--enablerepo=%s' % r for r in enablerepo]
-    if narrow_updates and action == 'query':
-        repo_arg.extend(['--upgrades'])
+        repo_arg = ["--enablerepo=%s" % r for r in enablerepo]
+    if narrow_updates and action == "query":
+        repo_arg.extend(["--upgrades"])
 
-    if action == 'clean':
-        cmd = ['yum', 'clean', 'all'] + (repo_arg if repo_arg else ["--enablerepo=*"])
-    elif action == 'install':
-        cmd = ['yum', 'install', '-y', '--exclude', 'kernel-debug'] + repo_arg + list(packages)
-    elif action == 'remove':
-        cmd = ['yum', 'remove', '-y'] + repo_arg + list(packages)
-    elif action == 'update':
-        cmd = ['yum', 'update', '-y', '--exclude', 'kernel-debug',] + repo_arg + list(packages)
-    elif action == 'requires':
-        cmd = ['repoquery', '--requires'] + repo_arg + list(packages)
-    elif action == 'query':
-        cmd = ['repoquery'] + repo_arg + list(packages)
-    elif action == 'repoquery':
-        cmd = ['repoquery', '--show-duplicates'] + repo_arg + \
-              ['--queryformat=%{EPOCH} %{NAME} ' \
-               '%{VERSION} %{RELEASE} %{ARCH}']
+    if action == "clean":
+        cmd = ["yum", "clean", "all"] + (repo_arg if repo_arg else ["--enablerepo=*"])
+    elif action == "install":
+        cmd = (
+            ["yum", "install", "-y", "--exclude", "kernel-debug"]
+            + repo_arg
+            + list(packages)
+        )
+    elif action == "remove":
+        cmd = ["yum", "remove", "-y"] + repo_arg + list(packages)
+    elif action == "update":
+        cmd = (
+            ["yum", "update", "-y", "--exclude", "kernel-debug"]
+            + repo_arg
+            + list(packages)
+        )
+    elif action == "requires":
+        cmd = ["repoquery", "--requires"] + repo_arg + list(packages)
+    elif action == "query":
+        cmd = ["repoquery"] + repo_arg + list(packages)
+    elif action == "repoquery":
+        cmd = (
+            ["repoquery", "--show-duplicates"]
+            + repo_arg
+            + ["--queryformat=%{EPOCH} %{NAME} " "%{VERSION} %{RELEASE} %{ARCH}"]
+        )
     else:
-        raise RuntimeError('Unknown yum util action %s' % action)
+        raise RuntimeError("Unknown yum util action %s" % action)
 
     # This is a poor solution for HYD-3855 but not one that carries any known cost.
     # We sometimes see intermittent failures in test, and possibly out of test, that occur
@@ -66,12 +71,13 @@ def yum_util(action,
         else:
             # if we were trying to install, clean the metadata before
             # trying again
-            if action == 'install':
-                AgentShell.run(['yum', 'clean', 'metadata'])
-            daemon_log.info(
-                "HYD-3885 Retrying yum command '%s'" % " ".join(cmd))
+            if action == "install":
+                AgentShell.run(["yum", "clean", "metadata"])
+            daemon_log.info("HYD-3885 Retrying yum command '%s'" % " ".join(cmd))
             if hyd_3885 == 0:
                 daemon_log.info(
-                    "HYD-3885 Retry yum command failed '%s'" % " ".join(cmd))
+                    "HYD-3885 Retry yum command failed '%s'" % " ".join(cmd)
+                )
                 raise AgentShell.CommandExecutionError(
-                    result, cmd)  # Out of retries so raise for the caller..
+                    result, cmd
+                )  # Out of retries so raise for the caller..

--- a/chroma_agent/log.py
+++ b/chroma_agent/log.py
@@ -11,20 +11,20 @@ import sys
 # This log is for messages about the internal machinations of our
 # daemon and messaging systems, the user would only be interested
 # in warnings and errors
-daemon_log = logging.getLogger('daemon')
+daemon_log = logging.getLogger("daemon")
 
 # This log is for copytool monitoring instances. Not particularly interesting
 # unless things have gone wrong.
-copytool_log = logging.getLogger('copytool')
+copytool_log = logging.getLogger("copytool")
 
 # This log is for messages about operations invoked at the user's request,
 # the user will be interested general breezy chat (INFO) about what we're
 # doing for them
-console_log = logging.getLogger('console')
+console_log = logging.getLogger("console")
 
 logging_in_debug_mode = os.path.exists("/tmp/chroma-agent-debug")
 
-if logging_in_debug_mode or 'nosetests' in sys.argv[0]:
+if logging_in_debug_mode or "nosetests" in sys.argv[0]:
     daemon_log.setLevel(logging.DEBUG)
     copytool_log.setLevel(logging.DEBUG)
     console_log.setLevel(logging.DEBUG)
@@ -41,8 +41,9 @@ def increase_loglevel(signal, frame):
     for logger in agent_loggers:
         # impossible to go below 10 -- logging resets to WARN
         logger.setLevel(logger.getEffectiveLevel() - 10)
-        logger.critical("Log level set to %s" %
-                        logging.getLevelName(logger.getEffectiveLevel()))
+        logger.critical(
+            "Log level set to %s" % logging.getLevelName(logger.getEffectiveLevel())
+        )
 
 
 def decrease_loglevel(signal, frame):
@@ -52,15 +53,20 @@ def decrease_loglevel(signal, frame):
         if current_level >= logging.CRITICAL:
             return
         logger.setLevel(current_level + 10)
-        logger.critical("Log level set to %s" %
-                        logging.getLevelName(logger.getEffectiveLevel()))
+        logger.critical(
+            "Log level set to %s" % logging.getLevelName(logger.getEffectiveLevel())
+        )
 
 
 # Not setting up logs at import time because we want to
 # set them up after daemonization
 def daemon_log_setup():
     handler = logging.FileHandler("/var/log/chroma-agent.log")
-    handler.setFormatter(logging.Formatter('[%(asctime)s] daemon %(levelname)s %(message)s', '%d/%b/%Y:%H:%M:%S'))
+    handler.setFormatter(
+        logging.Formatter(
+            "[%(asctime)s] daemon %(levelname)s %(message)s", "%d/%b/%Y:%H:%M:%S"
+        )
+    )
     daemon_log.addHandler(handler)
 
 
@@ -72,7 +78,7 @@ class SafeSyslogFormatter(logging.Formatter):
     def format(self, record):
         result = logging.Formatter.format(self, record)
         if isinstance(result, unicode):
-            result = result.encode('utf-8', 'replace')
+            result = result.encode("utf-8", "replace")
         return result
 
 
@@ -80,7 +86,11 @@ class SafeSyslogFormatter(logging.Formatter):
 def copytool_log_setup():
     handler = SysLogHandler(facility=SysLogHandler.LOG_DAEMON, address="/dev/log")
     # FIXME: define a custom formatter that will handle unicode strings
-    handler.setFormatter(SafeSyslogFormatter('[%(asctime)s] copytool %(levelname)s: %(message)s', '%d/%b/%Y:%H:%M:%S'))
+    handler.setFormatter(
+        SafeSyslogFormatter(
+            "[%(asctime)s] copytool %(levelname)s: %(message)s", "%d/%b/%Y:%H:%M:%S"
+        )
+    )
     copytool_log.addHandler(handler)
 
     # Hijack these so that we can reuse code without stomping on other
@@ -91,5 +101,9 @@ def copytool_log_setup():
 
 def console_log_setup():
     handler = logging.FileHandler("/var/log/chroma-agent-console.log")
-    handler.setFormatter(logging.Formatter('[%(asctime)s] console %(levelname)s %(message)s', '%d/%b/%Y:%H:%M:%S'))
+    handler.setFormatter(
+        logging.Formatter(
+            "[%(asctime)s] console %(levelname)s %(message)s", "%d/%b/%Y:%H:%M:%S"
+        )
+    )
     console_log.addHandler(handler)

--- a/chroma_agent/plugin_manager.py
+++ b/chroma_agent/plugin_manager.py
@@ -19,12 +19,13 @@ class PluginManager(object):
     Simple plugin framework with minimal boilerplate required.  Uses introspection
     to find subclasses of plugin_class in plugin_path.
     """
+
     plugin_path = None
     plugin_class = None
 
     @classmethod
     def get_plugins(cls):
-        if not hasattr(cls, '_plugins'):
+        if not hasattr(cls, "_plugins"):
             cls._find_plugins()
 
         return cls._plugins
@@ -37,7 +38,7 @@ class PluginManager(object):
             """Walk backwards up the tree to first non-module directory."""
             components = []
 
-            if (os.path.isfile("%s/__init__.py" % dir)):
+            if os.path.isfile("%s/__init__.py" % dir):
                 parent, child = os.path.split(dir)
                 components.append(child)
                 components.extend(_walk_parents(parent))
@@ -69,7 +70,7 @@ class PluginManager(object):
             try:
                 try:
                     __import__(name, None, None)
-                except ImportError, e:
+                except ImportError as e:
                     if e.args[0].endswith(" " + name):
                         daemon_log.warn("** plugin %s not found" % name)
                     else:
@@ -85,7 +86,7 @@ class PluginManager(object):
         cls._load_plugins(cls._scan_plugins(cls.plugin_path))
         cls._plugins = {}
         for plugin_class in cls.plugin_class.__subclasses__():
-            name = plugin_class.__module__.split('.')[-1]
+            name = plugin_class.__module__.split(".")[-1]
             cls._plugins[name] = plugin_class
 
 
@@ -94,7 +95,9 @@ class DevicePlugin(object):
     A plugin which maintains a state and sends and receives messages.
     """
 
-    FAILSAFEDUPDATE = 60                # We always send an update every 60 cycles (60*10)seconds - 10 minutes.
+    FAILSAFEDUPDATE = (
+        60
+    )  # We always send an update every 60 cycles (60*10)seconds - 10 minutes.
 
     def __init__(self, session):
         self._session = session
@@ -141,7 +144,7 @@ class DevicePlugin(object):
         """
         pass
 
-    def send_message(self, body, callback = None):
+    def send_message(self, body, callback=None):
         """
         Enqueue a message to be sent to the manager (returns immediately).
 
@@ -153,15 +156,19 @@ class DevicePlugin(object):
         else:
             self._session.send_message(DevicePluginMessage(body), callback)
 
-    def _delta_result(self, result, delta_fields = None):
+    def _delta_result(self, result, delta_fields=None):
         if not delta_fields:
             delta_fields = result.keys()
 
-        if (self._safety_send < DevicePlugin.FAILSAFEDUPDATE) and (self.trigger_plugin_update is False):
+        if (self._safety_send < DevicePlugin.FAILSAFEDUPDATE) and (
+            self.trigger_plugin_update is False
+        ):
             self._safety_send += 1
 
             for key in delta_fields:
-                if result[key] == self.last_result[key]:        # If the result is not new then don't send it.
+                if (
+                    result[key] == self.last_result[key]
+                ):  # If the result is not new then don't send it.
                     result[key] = None
                 else:
                     self.last_result[key] = result[key]
@@ -169,7 +176,9 @@ class DevicePlugin(object):
             self._safety_send = 0
             self.trigger_plugin_update = False
 
-        return result if result else None                       # Turn {} into None, None will mean no message sent.
+        return (
+            result if result else None
+        )  # Turn {} into None, None will mean no message sent.
 
     def _reset_delta(self):
         self.last_result = collections.defaultdict(lambda: None)
@@ -190,7 +199,8 @@ class DevicePluginMessageCollection(list):
     Return this instead of a naked {} or a DevicePluginMessage if you need to return
     multiple messages from one callback.
     """
-    def __init__(self, messages, priority = PRIO_NORMAL):
+
+    def __init__(self, messages, priority=PRIO_NORMAL):
         """
         :param messages: An iterable of JSON-serializable objects
         :param priority: One of PRIO_LOW, PRIO_NORMAL, PRIO_HIGH
@@ -205,7 +215,8 @@ class DevicePluginMessage(object):
 
     Return this instead of a naked {} if you need to set the priority.
     """
-    def __init__(self, message, priority = PRIO_NORMAL):
+
+    def __init__(self, message, priority=PRIO_NORMAL):
         """
         :param message: A JSON-serializable object
         :param priority: One of PRIO_LOW, PRIO_NORMAL, PRIO_HIGH
@@ -215,7 +226,9 @@ class DevicePluginMessage(object):
 
 
 class DevicePluginManager(PluginManager):
-    plugin_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'device_plugins')
+    plugin_path = os.path.join(
+        os.path.abspath(os.path.dirname(__file__)), "device_plugins"
+    )
     plugin_class = DevicePlugin
 
     def get(self, plugin_name):
@@ -223,7 +236,7 @@ class DevicePluginManager(PluginManager):
 
 
 class ActionPluginManager(object):
-    path = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'action_plugins')
+    path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "action_plugins")
     commands = None
     capabilities = None
 
@@ -235,7 +248,7 @@ class ActionPluginManager(object):
             """Walk backwards up the tree to first non-module directory."""
             components = []
 
-            if (os.path.isfile("%s/__init__.py" % dir)):
+            if os.path.isfile("%s/__init__.py" % dir):
                 parent, child = os.path.split(dir)
                 components.append(child)
                 components.extend(_walk_parents(parent))
@@ -261,18 +274,23 @@ class ActionPluginManager(object):
 
         cls.commands = {}
         capabilities = set()
-        for name in [n for n in names if not n.split(".")[-1].startswith('_')]:
+        for name in [n for n in names if not n.split(".")[-1].startswith("_")]:
             try:
-                module = __import__(name, None, None, ['ACTIONS', 'CAPABILITIES'])
-                if hasattr(module, 'ACTIONS'):
+                module = __import__(name, None, None, ["ACTIONS", "CAPABILITIES"])
+                if hasattr(module, "ACTIONS"):
                     for fn in module.ACTIONS:
                         cls.commands[fn.func_name] = fn
 
-                    daemon_log.info("Loaded actions from %s: %s" % (name, [fn.func_name for fn in module.ACTIONS]))
+                    daemon_log.info(
+                        "Loaded actions from %s: %s"
+                        % (name, [fn.func_name for fn in module.ACTIONS])
+                    )
                 else:
-                    daemon_log.warning("No 'ACTIONS' defined in action module %s" % name)
+                    daemon_log.warning(
+                        "No 'ACTIONS' defined in action module %s" % name
+                    )
 
-                if hasattr(module, 'CAPABILITIES') and module.CAPABILITIES:
+                if hasattr(module, "CAPABILITIES") and module.CAPABILITIES:
                     capabilities.add(*module.CAPABILITIES)
 
             except Exception:
@@ -297,7 +315,7 @@ class ActionPluginManager(object):
         # This feature was added just prior to 3.1 and whilst it would be better to always pass the context the
         # scope of the change was prohibitive at that time.
         # Not a fixme because it is of little value to make the additional changes at this time.
-        if 'agent_daemon_context' in fn.__code__.co_varnames:
+        if "agent_daemon_context" in fn.__code__.co_varnames:
             return fn(agent_daemon_context, **args)
         else:
             return fn(**args)

--- a/chroma_agent/utils.py
+++ b/chroma_agent/utils.py
@@ -10,7 +10,7 @@ from chroma_agent.lib.shell import AgentShell
 
 
 def lsof(pid=None, file=None):
-    lsof_args = ['lsof', '-F', 'pan0']
+    lsof_args = ["lsof", "-F", "pan0"]
 
     if pid:
         lsof_args += ["-p", str(pid)]
@@ -29,15 +29,15 @@ def lsof(pid=None, file=None):
         return pids
 
     for line in stdout.split("\n"):
-        match = re.match(r'^p(\d+)\x00', line)
+        match = re.match(r"^p(\d+)\x00", line)
         if match:
             current_pid = match.group(1)
             continue
 
-        match = re.match(r'^a(\w)\x00n(.*)\x00', line)
+        match = re.match(r"^a(\w)\x00n(.*)\x00", line)
         if match:
             mode = match.group(1)
             file = match.group(2)
-            pids[current_pid][file] = {'mode': mode}
+            pids[current_pid][file] = {"mode": mode}
 
     return pids

--- a/setup.py
+++ b/setup.py
@@ -7,42 +7,43 @@
 
 from setuptools import setup, find_packages
 from chroma_agent import package_version
+
 # To use a consistent encoding
 from codecs import open
 from os import path
 
 here = path.abspath(path.dirname(__file__))
 
-with open(path.join(here, 'README.rst'), encoding = 'utf-8') as f:
+with open(path.join(here, "README.rst"), encoding="utf-8") as f:
     long_description = f.read()
 
 excludes = ["*tests*"]
 
 setup(
-    name = 'iml-agent',
-    version = package_version(),
-    author = "whamCloud Team",
-    author_email = "iml@whamcloud.com",
-    url = 'https://pypi.python.org/pypi/iml-agent',
-    packages = find_packages(exclude=excludes),
-    include_package_data = True,
-    license = 'MIT',
-    description = 'The IML software Monitoring and Administration Interface Agent',
-    long_description = long_description,
-    classifiers = [
-        'Development Status :: 5 - Production/Stable',
-        'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
+    name="iml-agent",
+    version=package_version(),
+    author="whamCloud Team",
+    author_email="iml@whamcloud.com",
+    url="https://pypi.python.org/pypi/iml-agent",
+    packages=find_packages(exclude=excludes),
+    include_package_data=True,
+    license="MIT",
+    description="The IML software Monitoring and Administration Interface Agent",
+    long_description=long_description,
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
     ],
-    keywords = 'IML lustre high-availability',
-    data_files=[('/usr/lib/ocf/resource.d/chroma', ['Target', 'ZFS'])],
-    entry_points = {
-        'console_scripts': [
-            'chroma-agent = chroma_agent.cli:main',
-            'chroma-agent-daemon = chroma_agent.agent_daemon:main',
-            'chroma-copytool-monitor = chroma_agent.copytool_monitor:main',
-            'fence_chroma = chroma_agent.fence_chroma:main',
-        ],
-    }
+    keywords="IML lustre high-availability",
+    data_files=[("/usr/lib/ocf/resource.d/chroma", ["Target", "ZFS"])],
+    entry_points={
+        "console_scripts": [
+            "chroma-agent = chroma_agent.cli:main",
+            "chroma-agent-daemon = chroma_agent.agent_daemon:main",
+            "chroma-copytool-monitor = chroma_agent.copytool_monitor:main",
+            "fence_chroma = chroma_agent.fence_chroma:main",
+        ]
+    },
 )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,12 +5,13 @@ import threading
 import time
 
 
-chroma_logger = logging.getLogger('test')
+chroma_logger = logging.getLogger("test")
 chroma_logger.setLevel(logging.DEBUG)
 
 
 try:
     import nose
+
     nose_installed = True
 except ImportError:
     nose_installed = False
@@ -27,7 +28,7 @@ if nose_installed:
             self.stream.writeln(self._exc_info_to_string(err, test))
             chroma_logger.error(self._exc_info_to_string(err, test))
         elif self.dots:
-            self.stream.write('E')
+            self.stream.write("E")
             self.stream.flush()
 
     def monkeyPatchedAddFailure(self, test, err):
@@ -37,7 +38,7 @@ if nose_installed:
             self.stream.writeln(self._exc_info_to_string(err, test))
             chroma_logger.error(self._exc_info_to_string(err, test))
         elif self.dots:
-            self.stream.write('F')
+            self.stream.write("F")
             self.stream.flush()
 
     nose.result.TextTestResult.chroma_logger = chroma_logger
@@ -49,7 +50,10 @@ if nose_installed:
     def monkeyPatchedRun(self, test):
         self.descriptions = 0
         threads_at_beginning_of_test_run = threading.enumerate()
-        chroma_logger.info("Starting tests with these threads running: '%s'" % threads_at_beginning_of_test_run)
+        chroma_logger.info(
+            "Starting tests with these threads running: '%s'"
+            % threads_at_beginning_of_test_run
+        )
 
         wrapper = self.config.plugins.prepareTest(test)
         if wrapper is not None:
@@ -83,10 +87,15 @@ if nose_installed:
             time.sleep(5)
             running_time += 5
 
-        chroma_logger.info("Ending tests with these threads running: '%s'" % threading.enumerate())
+        chroma_logger.info(
+            "Ending tests with these threads running: '%s'" % threading.enumerate()
+        )
         hanging_threads = get_hanging_threads()
         if hanging_threads:
-            sys.stderr.write("\n********************\n\nTERMINATING TEST RUN - NOT ALL THREADS STOPPED AT END OF TESTS: '%s'\n\n********************\n" % hanging_threads)
+            sys.stderr.write(
+                "\n********************\n\nTERMINATING TEST RUN - NOT ALL THREADS STOPPED AT END OF TESTS: '%s'\n\n********************\n"
+                % hanging_threads
+            )
             os._exit(1)
 
         return result

--- a/tests/actions_plugins/test_agent_updates.py
+++ b/tests/actions_plugins/test_agent_updates.py
@@ -7,7 +7,10 @@ from mock import patch
 from chroma_agent.action_plugins import agent_updates
 from chroma_agent import config
 from iml_common.lib.shell import Shell
-from iml_common.test.command_capture_testcase import CommandCaptureTestCase, CommandCaptureCommand
+from iml_common.test.command_capture_testcase import (
+    CommandCaptureTestCase,
+    CommandCaptureCommand,
+)
 from iml_common.lib.agent_rpc import agent_result, agent_result_ok, agent_error
 
 
@@ -22,6 +25,7 @@ class TestManageUpdates(CommandCaptureTestCase):
 
     def test_configure_repo(self):
         import chroma_agent
+
         expected_content = """
 [Integrated-Manager-For-Lustre]
 name=Integrated Manager for Lustre updates
@@ -44,66 +48,70 @@ sslcacert = {0}
 sslclientkey = {1}
 sslclientcert = {2}
 """
-        with patch('os.rename', create=True) as mock_rename:
-            with patch('os.open', create=True):
-                with patch('os.fdopen', spec=file, create=True) as mock_fsopen:
+        with patch("os.rename", create=True) as mock_rename:
+            with patch("os.open", create=True):
+                with patch("os.fdopen", spec=file, create=True) as mock_fsopen:
                     with patch.object(
-                            chroma_agent.config,
-                            'path',
-                            "/var/lib/chroma/",
-                            create=True):
+                        chroma_agent.config, "path", "/var/lib/chroma/", create=True
+                    ):
                         self.assertEqual(
-                            agent_updates.configure_repo(
-                                'filename', provided_content), agent_result_ok)
+                            agent_updates.configure_repo("filename", provided_content),
+                            agent_result_ok,
+                        )
                         mock_fsopen.return_value.write.assert_called_once_with(
-                            expected_content)
+                            expected_content
+                        )
                         mock_rename.assert_called_once_with(
-                            '/etc/yum.repos.d/filename.tmp',
-                            '/etc/yum.repos.d/filename')
+                            "/etc/yum.repos.d/filename.tmp", "/etc/yum.repos.d/filename"
+                        )
 
     def test_unconfigure_repo(self):
         self.assertEqual(
-            agent_updates.unconfigure_repo(self.tmpRepo.name), agent_result_ok)
+            agent_updates.unconfigure_repo(self.tmpRepo.name), agent_result_ok
+        )
         self.assertFalse(os.path.exists(self.tmpRepo.name))
 
     def test_unconfigure_repo_no_file(self):
         os.remove(self.tmpRepo.name)
         self.assertFalse(os.path.exists(self.tmpRepo.name))
         self.assertEqual(
-            agent_updates.unconfigure_repo(self.tmpRepo.name), agent_result_ok)
+            agent_updates.unconfigure_repo(self.tmpRepo.name), agent_result_ok
+        )
 
     def test_kernel_status(self):
         def run(arg_list):
             values = {
-                ("rpm", "-q", "--whatprovides", "kmod-lustre"):
-                "kmod-lustre-1.2.3-1.el6.x86_64\n",
-                ("uname", "-r"):
-                "2.6.32-358.2.1.el6.x86_64\n",
-                ("rpm", "-q", "kernel"):
-                "kernel-2.6.32-358.2.1.el6.x86_64\n"
-                "kernel-2.6.32-358.18.1.el6_lustre.x86_64\n"
+                (
+                    "rpm",
+                    "-q",
+                    "--whatprovides",
+                    "kmod-lustre",
+                ): "kmod-lustre-1.2.3-1.el6.x86_64\n",
+                ("uname", "-r"): "2.6.32-358.2.1.el6.x86_64\n",
+                ("rpm", "-q", "kernel"): "kernel-2.6.32-358.2.1.el6.x86_64\n"
+                "kernel-2.6.32-358.18.1.el6_lustre.x86_64\n",
             }
             return Shell.RunResult(0, values[tuple(arg_list)], "", False)
 
-        with patch('chroma_agent.lib.shell.AgentShell.run', side_effect=run):
+        with patch("chroma_agent.lib.shell.AgentShell.run", side_effect=run):
             result = agent_updates.kernel_status()
             self.assertDictEqual(
-                result, {
-                    'required':
-                    'kernel-2.6.32-358.18.1.el6_lustre.x86_64',
-                    'running':
-                    'kernel-2.6.32-358.2.1.el6.x86_64',
-                    'available': [
+                result,
+                {
+                    "required": "kernel-2.6.32-358.18.1.el6_lustre.x86_64",
+                    "running": "kernel-2.6.32-358.2.1.el6.x86_64",
+                    "available": [
                         "kernel-2.6.32-358.2.1.el6.x86_64",
-                        "kernel-2.6.32-358.18.1.el6_lustre.x86_64"
-                    ]
-                })
+                        "kernel-2.6.32-358.18.1.el6_lustre.x86_64",
+                    ],
+                },
+            )
 
     def test_install_packages(self):
         self.add_commands(
-            CommandCaptureCommand(('yum', 'clean', 'all', '--enablerepo=*')),
+            CommandCaptureCommand(("yum", "clean", "all", "--enablerepo=*")),
             CommandCaptureCommand(
-                ('repoquery', '--requires', '--enablerepo=myrepo', 'foo', 'bar'),
+                ("repoquery", "--requires", "--enablerepo=myrepo", "foo", "bar"),
                 stdout="""/usr/bin/python
 python >= 2.4
 python(abi) = 2.6
@@ -111,34 +119,45 @@ yum >= 3.2.29
 /bin/sh
 kernel = 2.6.32-279.14.1.el6_lustre
 lustre-backend-fs
-        """),
+        """,
+            ),
             CommandCaptureCommand(
-                ('yum', 'install', '-y', '--exclude',
-                 'kernel-debug', '--enablerepo=myrepo', 'foo', 'bar',
-                 'kernel-2.6.32-279.14.1.el6_lustre')),
+                (
+                    "yum",
+                    "install",
+                    "-y",
+                    "--exclude",
+                    "kernel-debug",
+                    "--enablerepo=myrepo",
+                    "foo",
+                    "bar",
+                    "kernel-2.6.32-279.14.1.el6_lustre",
+                )
+            ),
             CommandCaptureCommand(
-                ('grubby', '--default-kernel'),
-                stdout='/boot/vmlinuz-2.6.32-504.3.3.el6.x86_64'),
-            CommandCaptureCommand(('systemctl', 'start', 'iml-update-check')),
-            CommandCaptureCommand(('systemctl', 'is-active',
-                                   'iml-update-check')),
+                ("grubby", "--default-kernel"),
+                stdout="/boot/vmlinuz-2.6.32-504.3.3.el6.x86_64",
+            ),
+            CommandCaptureCommand(("systemctl", "start", "iml-update-check")),
+            CommandCaptureCommand(("systemctl", "is-active", "iml-update-check")),
         )
 
         def isfile(arg):
             return True
 
-        with patch('os.path.isfile', side_effect=isfile):
+        with patch("os.path.isfile", side_effect=isfile):
             self.assertEqual(
-                agent_updates.install_packages(['myrepo'], ['foo', 'bar']),
-                agent_result_ok)
+                agent_updates.install_packages(["myrepo"], ["foo", "bar"]),
+                agent_result_ok,
+            )
 
         self.assertRanAllCommandsInOrder()
 
     def test_install_packages_hyd_4050_grubby(self):
         self.add_commands(
-            CommandCaptureCommand(('yum', 'clean', 'all', '--enablerepo=*')),
+            CommandCaptureCommand(("yum", "clean", "all", "--enablerepo=*")),
             CommandCaptureCommand(
-                ('repoquery', '--requires', '--enablerepo=myrepo', 'foo'),
+                ("repoquery", "--requires", "--enablerepo=myrepo", "foo"),
                 stdout="""/usr/bin/python
 python >= 2.4
 python(abi) = 2.6
@@ -146,28 +165,38 @@ yum >= 3.2.29
 /bin/sh
 kernel = 2.6.32-279.14.1.el6_lustre
 lustre-backend-fs
-        """),
+        """,
+            ),
             CommandCaptureCommand(
-                ('yum', 'install', '-y', '--exclude',
-                 'kernel-debug', '--enablerepo=myrepo', 'foo',
-                 'kernel-2.6.32-279.14.1.el6_lustre')),
-            CommandCaptureCommand(('grubby', '--default-kernel'), rc=1))
+                (
+                    "yum",
+                    "install",
+                    "-y",
+                    "--exclude",
+                    "kernel-debug",
+                    "--enablerepo=myrepo",
+                    "foo",
+                    "kernel-2.6.32-279.14.1.el6_lustre",
+                )
+            ),
+            CommandCaptureCommand(("grubby", "--default-kernel"), rc=1),
+        )
 
         def isfile(arg):
             return True
 
-        with patch('os.path.isfile', side_effect=isfile):
+        with patch("os.path.isfile", side_effect=isfile):
             self.assertTrue(
-                'error' in agent_updates.install_packages(['myrepo'], ['foo']))
+                "error" in agent_updates.install_packages(["myrepo"], ["foo"])
+            )
 
         self.assertRanAllCommandsInOrder()
 
     def test_install_packages_4050_initramfs(self):
         self.add_commands(
-            CommandCaptureCommand(('yum', 'clean', 'all', '--enablerepo=*')),
+            CommandCaptureCommand(("yum", "clean", "all", "--enablerepo=*")),
             CommandCaptureCommand(
-                ('repoquery', '--requires',
-                 '--enablerepo=myrepo', 'foo'),
+                ("repoquery", "--requires", "--enablerepo=myrepo", "foo"),
                 stdout="""/usr/bin/python
 python >= 2.4
 python(abi) = 2.6
@@ -175,88 +204,124 @@ yum >= 3.2.29
 /bin/sh
 kernel = 2.6.32-279.14.1.el6_lustre
 lustre-backend-fs
-        """),
+        """,
+            ),
             CommandCaptureCommand(
-                ('yum', 'install', '-y', '--exclude',
-                 'kernel-debug', '--enablerepo=myrepo', 'foo',
-                 'kernel-2.6.32-279.14.1.el6_lustre')),
+                (
+                    "yum",
+                    "install",
+                    "-y",
+                    "--exclude",
+                    "kernel-debug",
+                    "--enablerepo=myrepo",
+                    "foo",
+                    "kernel-2.6.32-279.14.1.el6_lustre",
+                )
+            ),
             CommandCaptureCommand(
-                ('grubby', '--default-kernel'),
-                stdout='/boot/vmlinuz-2.6.32-504.3.3.el6.x86_64'))
+                ("grubby", "--default-kernel"),
+                stdout="/boot/vmlinuz-2.6.32-504.3.3.el6.x86_64",
+            ),
+        )
 
         def isfile(arg):
             return False
 
-        with patch('os.path.isfile', side_effect=isfile):
+        with patch("os.path.isfile", side_effect=isfile):
             self.assertTrue(
-                'error' in agent_updates.install_packages(['myrepo'], ['foo']))
+                "error" in agent_updates.install_packages(["myrepo"], ["foo"])
+            )
 
         self.assertRanAllCommandsInOrder()
 
     def test_set_profile_success(self):
-        config.update('settings', 'profile', {'managed': False})
+        config.update("settings", "profile", {"managed": False})
 
         # Go from managed = False to managed = True
         self.add_command(
-            ('yum', 'install', '-y', '--exclude',
-             'kernel-debug', 'python2-iml-agent-management'))
+            (
+                "yum",
+                "install",
+                "-y",
+                "--exclude",
+                "kernel-debug",
+                "python2-iml-agent-management",
+            )
+        )
         self.assertEqual(
-            agent_updates.update_profile({
-                'managed': True
-            }), agent_result_ok)
+            agent_updates.update_profile({"managed": True}), agent_result_ok
+        )
         self.assertRanAllCommandsInOrder()
 
         # Go from managed = True to managed = False
         self.reset_command_capture()
-        self.add_command(('yum', 'remove', '-y',
-                          'python2-iml-agent-management'))
+        self.add_command(("yum", "remove", "-y", "python2-iml-agent-management"))
         self.assertEqual(
-            agent_updates.update_profile({
-                'managed': False
-            }), agent_result_ok)
+            agent_updates.update_profile({"managed": False}), agent_result_ok
+        )
         self.assertRanAllCommandsInOrder()
 
         # Go from managed = False to managed = False
         self.reset_command_capture()
         self.assertEqual(
-            agent_updates.update_profile({
-                'managed': False
-            }), agent_result_ok)
+            agent_updates.update_profile({"managed": False}), agent_result_ok
+        )
         self.assertRanAllCommandsInOrder()
 
     def test_set_profile_fail(self):
         # Three times because yum will try three times.
         self.add_commands(
             CommandCaptureCommand(
-                ('yum', 'install', '-y', '--exclude',
-                 'kernel-debug', 'python2-iml-agent-management'),
+                (
+                    "yum",
+                    "install",
+                    "-y",
+                    "--exclude",
+                    "kernel-debug",
+                    "python2-iml-agent-management",
+                ),
                 rc=1,
                 stdout="Bad command stdout",
-                stderr="Bad command stderr"),
-            CommandCaptureCommand(('yum', 'clean', 'metadata')),
+                stderr="Bad command stderr",
+            ),
+            CommandCaptureCommand(("yum", "clean", "metadata")),
             CommandCaptureCommand(
-                ('yum', 'install', '-y', '--exclude',
-                 'kernel-debug', 'python2-iml-agent-management'),
+                (
+                    "yum",
+                    "install",
+                    "-y",
+                    "--exclude",
+                    "kernel-debug",
+                    "python2-iml-agent-management",
+                ),
                 rc=1,
                 stdout="Bad command stdout",
-                stderr="Bad command stderr"),
-            CommandCaptureCommand(('yum', 'clean', 'metadata')),
+                stderr="Bad command stderr",
+            ),
+            CommandCaptureCommand(("yum", "clean", "metadata")),
             CommandCaptureCommand(
-                ('yum', 'install', '-y', '--exclude',
-                 'kernel-debug', 'python2-iml-agent-management'),
+                (
+                    "yum",
+                    "install",
+                    "-y",
+                    "--exclude",
+                    "kernel-debug",
+                    "python2-iml-agent-management",
+                ),
                 rc=1,
                 stdout="Bad command stdout",
-                stderr="Bad command stderr"),
-            CommandCaptureCommand(('yum', 'clean', 'metadata')))
+                stderr="Bad command stderr",
+            ),
+            CommandCaptureCommand(("yum", "clean", "metadata")),
+        )
 
-        config.update('settings', 'profile', {'managed': False})
+        config.update("settings", "profile", {"managed": False})
 
         # Go from managed = False to managed = True, but it will fail.
         self.assertEqual(
-            agent_updates.update_profile({
-                'managed': True
-            }),
+            agent_updates.update_profile({"managed": True}),
             agent_error(
-                'Unable to set profile because yum returned Bad command stdout'
-            ))
+                "Unable to set profile because yum returned Bad command stdout"
+            ),
+        )
         self.assertRanAllCommandsInOrder()

--- a/tests/actions_plugins/test_manage_client_mounts.py
+++ b/tests/actions_plugins/test_manage_client_mounts.py
@@ -9,65 +9,84 @@ class TestClientMountManagement(CommandCaptureTestCase):
     def setUp(self):
         super(TestClientMountManagement, self).setUp()
 
-        client_root = '/mnt/lustre_clients'
+        client_root = "/mnt/lustre_clients"
         self.client_root = client_root
-        self.fsname = 'foobar'
-        self.mountspec = '1.2.3.4@tcp:/%s' % self.fsname
+        self.fsname = "foobar"
+        self.mountspec = "1.2.3.4@tcp:/%s" % self.fsname
         self.mountpoint = os.path.join(client_root, self.fsname)
 
-    @patch('chroma_agent.action_plugins.manage_client_mounts.delete_fstab_entry')
-    @patch('chroma_agent.action_plugins.manage_client_mounts.create_fstab_entry')
+    @patch("chroma_agent.action_plugins.manage_client_mounts.delete_fstab_entry")
+    @patch("chroma_agent.action_plugins.manage_client_mounts.create_fstab_entry")
     def test_mount_lustre_filesystem(self, create, delete):
-        self.add_command(('/bin/mount', '/mnt/lustre_clients/foobar'))
+        self.add_command(("/bin/mount", "/mnt/lustre_clients/foobar"))
 
-        from chroma_agent.action_plugins.manage_client_mounts import mount_lustre_filesystem
+        from chroma_agent.action_plugins.manage_client_mounts import (
+            mount_lustre_filesystem,
+        )
 
-        with patch('os.makedirs') as makedirs:
+        with patch("os.makedirs") as makedirs:
             mount_lustre_filesystem(self.mountspec, self.mountpoint)
-            makedirs.assert_called_with(self.mountpoint, 0755)
+            makedirs.assert_called_with(self.mountpoint, 0o755)
 
         self.assertRanAllCommandsInOrder()
         create.assert_called_with(self.mountspec, self.mountpoint)
 
-    @patch('chroma_agent.action_plugins.manage_client_mounts.delete_fstab_entry')
-    @patch('chroma_agent.action_plugins.manage_client_mounts.create_fstab_entry')
+    @patch("chroma_agent.action_plugins.manage_client_mounts.delete_fstab_entry")
+    @patch("chroma_agent.action_plugins.manage_client_mounts.create_fstab_entry")
     def test_mount_lustre_filesystems(self, *patches):
-        from chroma_agent.action_plugins.manage_client_mounts import mount_lustre_filesystems
+        from chroma_agent.action_plugins.manage_client_mounts import (
+            mount_lustre_filesystems,
+        )
 
-        with patch('chroma_agent.action_plugins.manage_client_mounts.mount_lustre_filesystem') as mlf:
+        with patch(
+            "chroma_agent.action_plugins.manage_client_mounts.mount_lustre_filesystem"
+        ) as mlf:
             mount_lustre_filesystems([(self.mountspec, self.mountpoint)])
             mlf.assert_called_with(self.mountspec, self.mountpoint)
 
-    @patch('chroma_agent.action_plugins.manage_client_mounts.delete_fstab_entry')
+    @patch("chroma_agent.action_plugins.manage_client_mounts.delete_fstab_entry")
     def test_unmount_lustre_filesystem(self, *patches):
-        self.add_command(('/bin/umount', '/mnt/lustre_clients/foobar'))
+        self.add_command(("/bin/umount", "/mnt/lustre_clients/foobar"))
 
-        from chroma_agent.action_plugins.manage_client_mounts import unmount_lustre_filesystem
+        from chroma_agent.action_plugins.manage_client_mounts import (
+            unmount_lustre_filesystem,
+        )
 
         unmount_lustre_filesystem(self.mountspec, self.mountpoint)
 
         self.assertRanAllCommandsInOrder()
 
-    @patch('chroma_agent.action_plugins.manage_client_mounts.delete_fstab_entry')
+    @patch("chroma_agent.action_plugins.manage_client_mounts.delete_fstab_entry")
     def test_unmount_lustre_filesystems(self, *patches):
-        from chroma_agent.action_plugins.manage_client_mounts import unmount_lustre_filesystems
+        from chroma_agent.action_plugins.manage_client_mounts import (
+            unmount_lustre_filesystems,
+        )
 
-        with patch('chroma_agent.action_plugins.manage_client_mounts.unmount_lustre_filesystem') as ulf:
+        with patch(
+            "chroma_agent.action_plugins.manage_client_mounts.unmount_lustre_filesystem"
+        ) as ulf:
             unmount_lustre_filesystems([(self.mountspec, self.mountpoint)])
             ulf.assert_called_with(self.mountspec, self.mountpoint)
 
-    @patch('chroma_agent.action_plugins.manage_client_mounts.delete_fstab_entry')
+    @patch("chroma_agent.action_plugins.manage_client_mounts.delete_fstab_entry")
     def test_create_fstab_entry(self, delete):
-        from chroma_agent.action_plugins.manage_client_mounts import FSTAB_ENTRY_TEMPLATE, create_fstab_entry
+        from chroma_agent.action_plugins.manage_client_mounts import (
+            FSTAB_ENTRY_TEMPLATE,
+            create_fstab_entry,
+        )
 
-        with patch('chroma_agent.action_plugins.manage_client_mounts.open',
-                   mock_open(), create=True) as mo:
+        with patch(
+            "chroma_agent.action_plugins.manage_client_mounts.open",
+            mock_open(),
+            create=True,
+        ) as mo:
             create_fstab_entry(self.mountspec, self.mountpoint)
-            mo().write.assert_called_once_with(FSTAB_ENTRY_TEMPLATE %
-                                               (self.mountspec, self.mountpoint))
+            mo().write.assert_called_once_with(
+                FSTAB_ENTRY_TEMPLATE % (self.mountspec, self.mountpoint)
+            )
         delete.assert_called_with(self.mountspec, self.mountpoint)
 
-    @patch('os.rename')
+    @patch("os.rename")
     def test_delete_fstab_entry(self, rename):
         from chroma_agent.action_plugins.manage_client_mounts import delete_fstab_entry
 
@@ -80,23 +99,29 @@ class TestClientMountManagement(CommandCaptureTestCase):
 %(mountspec)s1              %(mountpoint)s1          lustre      defaults,_netdev    0 0
 
 1.2.3.4:/baz    /qux        nfs         defaults    0 0
-""" % dict(mountspec = self.mountspec, mountpoint = self.mountpoint)
+""" % dict(
+            mountspec=self.mountspec, mountpoint=self.mountpoint
+        )
         data = StringIO(fake_fstab)
 
-        with patch('chroma_agent.action_plugins.manage_client_mounts.open',
-                   mock_open(), create=True) as mo:
+        with patch(
+            "chroma_agent.action_plugins.manage_client_mounts.open",
+            mock_open(),
+            create=True,
+        ) as mo:
             mo.return_value.__iter__.return_value = data
             delete_fstab_entry(self.mountspec, self.mountpoint)
 
             new_fstab = [c[1][0] for c in mo().write.mock_calls]
             self.assertMatchInList(r"^# /etc/fstab", new_fstab)
-            self.assertMatchInList(r'^%s1\s' % self.mountspec, new_fstab)
-            self.assertNotMatchInList(r'^%s\s' % self.mountspec, new_fstab)
+            self.assertMatchInList(r"^%s1\s" % self.mountspec, new_fstab)
+            self.assertNotMatchInList(r"^%s\s" % self.mountspec, new_fstab)
             self.assertMatchInList(r"^1.2.3.4:/baz", new_fstab)
         rename.assert_called_with("/etc/fstab.iml.edit", "/etc/fstab")
 
     def assertMatchInList(self, pattern, array):
         import re
+
         if isinstance(pattern, basestring):
             pattern = re.compile(pattern)
 

--- a/tests/actions_plugins/test_manage_copytool.py
+++ b/tests/actions_plugins/test_manage_copytool.py
@@ -2,8 +2,19 @@ import tempfile
 import shutil
 import mock
 
-from iml_common.test.command_capture_testcase import CommandCaptureTestCase, CommandCaptureCommand
-from chroma_agent.action_plugins.manage_copytool import start_monitored_copytool, stop_monitored_copytool, configure_copytool, unconfigure_copytool, update_copytool, list_copytools, _copytool_vars
+from iml_common.test.command_capture_testcase import (
+    CommandCaptureTestCase,
+    CommandCaptureCommand,
+)
+from chroma_agent.action_plugins.manage_copytool import (
+    start_monitored_copytool,
+    stop_monitored_copytool,
+    configure_copytool,
+    unconfigure_copytool,
+    update_copytool,
+    list_copytools,
+    _copytool_vars,
+)
 from tests.lib.agent_unit_testcase import AgentUnitTestCase
 
 
@@ -12,26 +23,34 @@ class TestCopytoolManagement(CommandCaptureTestCase, AgentUnitTestCase):
         super(TestCopytoolManagement, self).setUp()
 
         from chroma_agent.config_store import ConfigStore
-        self.mock_config = ConfigStore(tempfile.mkdtemp())
-        mock.patch('chroma_agent.action_plugins.manage_copytool.config', self.mock_config).start()
-        mock.patch('chroma_agent.copytool_monitor.config', self.mock_config).start()
-        mock.patch('chroma_agent.action_plugins.settings_management.config', self.mock_config).start()
 
-        mock.patch('chroma_agent.action_plugins.manage_copytool._write_service_init').start()
+        self.mock_config = ConfigStore(tempfile.mkdtemp())
+        mock.patch(
+            "chroma_agent.action_plugins.manage_copytool.config", self.mock_config
+        ).start()
+        mock.patch("chroma_agent.copytool_monitor.config", self.mock_config).start()
+        mock.patch(
+            "chroma_agent.action_plugins.settings_management.config", self.mock_config
+        ).start()
+
+        mock.patch(
+            "chroma_agent.action_plugins.manage_copytool._write_service_init"
+        ).start()
 
         self.mock_os_remove = mock.MagicMock()
-        mock.patch('os.remove', self.mock_os_remove).start()
+        mock.patch("os.remove", self.mock_os_remove).start()
 
         from chroma_agent.action_plugins.settings_management import reset_agent_config
+
         reset_agent_config()
 
-        self.ct_id = '42'
+        self.ct_id = "42"
         self.ct_index = 0
         self.ct_archive = 1
-        self.ct_bin_path = '/usr/sbin/lhsmtool_foo'
-        self.ct_arguments = '-p /archive/testfs'
-        self.ct_filesystem = 'testfs'
-        self.ct_mountpoint = '/mnt/testfs'
+        self.ct_bin_path = "/usr/sbin/lhsmtool_foo"
+        self.ct_arguments = "-p /archive/testfs"
+        self.ct_filesystem = "testfs"
+        self.ct_mountpoint = "/mnt/testfs"
         self._configure_copytool()
         self.ct_vars = _copytool_vars(self.ct_id)
 
@@ -45,122 +64,205 @@ class TestCopytoolManagement(CommandCaptureTestCase, AgentUnitTestCase):
         shutil.rmtree(self.mock_config.path)
 
     def _configure_copytool(self):
-        self.ct_id = configure_copytool(self.ct_id,
-                                       self.ct_index,
-                                       self.ct_bin_path,
-                                       self.ct_archive,
-                                       self.ct_filesystem,
-                                       self.ct_mountpoint,
-                                       self.ct_arguments)
+        self.ct_id = configure_copytool(
+            self.ct_id,
+            self.ct_index,
+            self.ct_bin_path,
+            self.ct_archive,
+            self.ct_filesystem,
+            self.ct_mountpoint,
+            self.ct_arguments,
+        )
 
     def test_start_monitored_copytool(self):
-        self.single_commands(CommandCaptureCommand(('systemctl', 'daemon-reload')),
-                             CommandCaptureCommand(('systemctl', 'is-active', 'chroma-copytool-monitor-%s' % self.ct_id), rc=1),
-                             CommandCaptureCommand(('systemctl', 'start', 'chroma-copytool-monitor-%s' % self.ct_id)),
-                             CommandCaptureCommand(('systemctl', 'is-active', 'chroma-copytool-monitor-%s' % self.ct_id)),
-                             CommandCaptureCommand(('systemctl', 'daemon-reload')),
-                             CommandCaptureCommand(('systemctl', 'is-active', 'chroma-copytool-%s' % self.ct_id), rc=1),
-                             CommandCaptureCommand(('systemctl', 'start', 'chroma-copytool-%s' % self.ct_id)),
-                             CommandCaptureCommand(('systemctl', 'is-active', 'chroma-copytool-%s' % self.ct_id)))
+        self.single_commands(
+            CommandCaptureCommand(("systemctl", "daemon-reload")),
+            CommandCaptureCommand(
+                ("systemctl", "is-active", "chroma-copytool-monitor-%s" % self.ct_id),
+                rc=1,
+            ),
+            CommandCaptureCommand(
+                ("systemctl", "start", "chroma-copytool-monitor-%s" % self.ct_id)
+            ),
+            CommandCaptureCommand(
+                ("systemctl", "is-active", "chroma-copytool-monitor-%s" % self.ct_id)
+            ),
+            CommandCaptureCommand(("systemctl", "daemon-reload")),
+            CommandCaptureCommand(
+                ("systemctl", "is-active", "chroma-copytool-%s" % self.ct_id), rc=1
+            ),
+            CommandCaptureCommand(
+                ("systemctl", "start", "chroma-copytool-%s" % self.ct_id)
+            ),
+            CommandCaptureCommand(
+                ("systemctl", "is-active", "chroma-copytool-%s" % self.ct_id)
+            ),
+        )
 
         self.assertAgentOK(start_monitored_copytool(self.ct_id))
         self.assertRanAllCommandsInOrder()
 
     def test_stop_monitored_copytool(self):
-        self.single_commands(CommandCaptureCommand(('systemctl', 'is-active', 'chroma-copytool-monitor-%s' % self.ct_id)),
-                             CommandCaptureCommand(('systemctl', 'stop', 'chroma-copytool-monitor-%s' % self.ct_id)),
-                             CommandCaptureCommand(('systemctl', 'is-active', 'chroma-copytool-monitor-%s' % self.ct_id), rc=1),
-                             CommandCaptureCommand(('systemctl', 'daemon-reload')),
-                             CommandCaptureCommand(('systemctl', 'is-active', 'chroma-copytool-%s' % self.ct_id)),
-                             CommandCaptureCommand(('systemctl', 'stop', 'chroma-copytool-%s' % self.ct_id)),
-                             CommandCaptureCommand(('systemctl', 'is-active', 'chroma-copytool-%s' % self.ct_id), rc=1),
-                             CommandCaptureCommand(('systemctl', 'daemon-reload')))
+        self.single_commands(
+            CommandCaptureCommand(
+                ("systemctl", "is-active", "chroma-copytool-monitor-%s" % self.ct_id)
+            ),
+            CommandCaptureCommand(
+                ("systemctl", "stop", "chroma-copytool-monitor-%s" % self.ct_id)
+            ),
+            CommandCaptureCommand(
+                ("systemctl", "is-active", "chroma-copytool-monitor-%s" % self.ct_id),
+                rc=1,
+            ),
+            CommandCaptureCommand(("systemctl", "daemon-reload")),
+            CommandCaptureCommand(
+                ("systemctl", "is-active", "chroma-copytool-%s" % self.ct_id)
+            ),
+            CommandCaptureCommand(
+                ("systemctl", "stop", "chroma-copytool-%s" % self.ct_id)
+            ),
+            CommandCaptureCommand(
+                ("systemctl", "is-active", "chroma-copytool-%s" % self.ct_id), rc=1
+            ),
+            CommandCaptureCommand(("systemctl", "daemon-reload")),
+        )
 
-        with mock.patch('os.path.exists', return_value=True):
+        with mock.patch("os.path.exists", return_value=True):
             self.assertAgentOK(stop_monitored_copytool(self.ct_id))
 
         self.assertRanAllCommandsInOrder()
         self.assertEqual(self.mock_os_remove.call_count, 2)
-        self.mock_os_remove.assert_called_with('/etc/init.d/chroma-copytool-%s' % self.ct_id)
+        self.mock_os_remove.assert_called_with(
+            "/etc/init.d/chroma-copytool-%s" % self.ct_id
+        )
 
     def test_start_should_be_idempotent(self):
-        self.single_commands(CommandCaptureCommand(('systemctl', 'daemon-reload')),
-                             CommandCaptureCommand(('systemctl', 'is-active', 'chroma-copytool-monitor-%s' % self.ct_id)),
-                             CommandCaptureCommand(('systemctl', 'stop', 'chroma-copytool-monitor-%s' % self.ct_id)),
-                             CommandCaptureCommand(('systemctl', 'is-active', 'chroma-copytool-monitor-%s' % self.ct_id), rc=1),
-                             CommandCaptureCommand(('systemctl', 'start', 'chroma-copytool-monitor-%s' % self.ct_id)),
-                             CommandCaptureCommand(('systemctl', 'is-active', 'chroma-copytool-monitor-%s' % self.ct_id)),
-                             CommandCaptureCommand(('systemctl', 'daemon-reload')),
-                             CommandCaptureCommand(('systemctl', 'is-active', 'chroma-copytool-%s' % self.ct_id)),
-                             CommandCaptureCommand(('systemctl', 'stop', 'chroma-copytool-%s' % self.ct_id)),
-                             CommandCaptureCommand(('systemctl', 'is-active', 'chroma-copytool-%s' % self.ct_id), rc=1),
-                             CommandCaptureCommand(('systemctl', 'start', 'chroma-copytool-%s' % self.ct_id)),
-                             CommandCaptureCommand(('systemctl', 'is-active', 'chroma-copytool-%s' % self.ct_id)))
+        self.single_commands(
+            CommandCaptureCommand(("systemctl", "daemon-reload")),
+            CommandCaptureCommand(
+                ("systemctl", "is-active", "chroma-copytool-monitor-%s" % self.ct_id)
+            ),
+            CommandCaptureCommand(
+                ("systemctl", "stop", "chroma-copytool-monitor-%s" % self.ct_id)
+            ),
+            CommandCaptureCommand(
+                ("systemctl", "is-active", "chroma-copytool-monitor-%s" % self.ct_id),
+                rc=1,
+            ),
+            CommandCaptureCommand(
+                ("systemctl", "start", "chroma-copytool-monitor-%s" % self.ct_id)
+            ),
+            CommandCaptureCommand(
+                ("systemctl", "is-active", "chroma-copytool-monitor-%s" % self.ct_id)
+            ),
+            CommandCaptureCommand(("systemctl", "daemon-reload")),
+            CommandCaptureCommand(
+                ("systemctl", "is-active", "chroma-copytool-%s" % self.ct_id)
+            ),
+            CommandCaptureCommand(
+                ("systemctl", "stop", "chroma-copytool-%s" % self.ct_id)
+            ),
+            CommandCaptureCommand(
+                ("systemctl", "is-active", "chroma-copytool-%s" % self.ct_id), rc=1
+            ),
+            CommandCaptureCommand(
+                ("systemctl", "start", "chroma-copytool-%s" % self.ct_id)
+            ),
+            CommandCaptureCommand(
+                ("systemctl", "is-active", "chroma-copytool-%s" % self.ct_id)
+            ),
+        )
 
         self.assertAgentOK(start_monitored_copytool(self.ct_id))
         self.assertRanAllCommandsInOrder()
 
     def test_stop_should_be_idempotent1(self):
-        self.single_commands(CommandCaptureCommand(('systemctl', 'is-active', 'chroma-copytool-monitor-%s' % self.ct_id)),
-                             CommandCaptureCommand(('systemctl', 'stop', 'chroma-copytool-monitor-%s' % self.ct_id)),
-                             CommandCaptureCommand(('systemctl', 'is-active', 'chroma-copytool-monitor-%s' % self.ct_id), rc=1),
-                             CommandCaptureCommand(('systemctl', 'daemon-reload')),
-                             CommandCaptureCommand(('systemctl', 'is-active', 'chroma-copytool-%s' % self.ct_id)),
-                             CommandCaptureCommand(('systemctl', 'stop', 'chroma-copytool-%s' % self.ct_id)),
-                             CommandCaptureCommand(('systemctl', 'is-active', 'chroma-copytool-%s' % self.ct_id), rc=1),
-                             CommandCaptureCommand(('systemctl', 'daemon-reload')),
-                             CommandCaptureCommand(('systemctl', 'daemon-reload')),
-                             CommandCaptureCommand(('systemctl', 'daemon-reload')))
+        self.single_commands(
+            CommandCaptureCommand(
+                ("systemctl", "is-active", "chroma-copytool-monitor-%s" % self.ct_id)
+            ),
+            CommandCaptureCommand(
+                ("systemctl", "stop", "chroma-copytool-monitor-%s" % self.ct_id)
+            ),
+            CommandCaptureCommand(
+                ("systemctl", "is-active", "chroma-copytool-monitor-%s" % self.ct_id),
+                rc=1,
+            ),
+            CommandCaptureCommand(("systemctl", "daemon-reload")),
+            CommandCaptureCommand(
+                ("systemctl", "is-active", "chroma-copytool-%s" % self.ct_id)
+            ),
+            CommandCaptureCommand(
+                ("systemctl", "stop", "chroma-copytool-%s" % self.ct_id)
+            ),
+            CommandCaptureCommand(
+                ("systemctl", "is-active", "chroma-copytool-%s" % self.ct_id), rc=1
+            ),
+            CommandCaptureCommand(("systemctl", "daemon-reload")),
+            CommandCaptureCommand(("systemctl", "daemon-reload")),
+            CommandCaptureCommand(("systemctl", "daemon-reload")),
+        )
 
-        with mock.patch('os.path.exists', return_value=True):
+        with mock.patch("os.path.exists", return_value=True):
             self.assertAgentOK(stop_monitored_copytool(self.ct_id))
 
-        with mock.patch('os.path.exists', return_value=False):
+        with mock.patch("os.path.exists", return_value=False):
             self.assertAgentOK(stop_monitored_copytool(self.ct_id))
 
         self.assertRanAllCommandsInOrder()
 
     def test_stop_should_be_idempotent2(self):
-        self.single_commands(CommandCaptureCommand(('systemctl', 'is-active', 'chroma-copytool-monitor-%s' % self.ct_id), rc=1),
-                             CommandCaptureCommand(('systemctl', 'daemon-reload')),
-                             CommandCaptureCommand(('systemctl', 'is-active', 'chroma-copytool-%s' % self.ct_id), rc=1),
-                             CommandCaptureCommand(('systemctl', 'daemon-reload')))
+        self.single_commands(
+            CommandCaptureCommand(
+                ("systemctl", "is-active", "chroma-copytool-monitor-%s" % self.ct_id),
+                rc=1,
+            ),
+            CommandCaptureCommand(("systemctl", "daemon-reload")),
+            CommandCaptureCommand(
+                ("systemctl", "is-active", "chroma-copytool-%s" % self.ct_id), rc=1
+            ),
+            CommandCaptureCommand(("systemctl", "daemon-reload")),
+        )
 
-        with mock.patch('os.path.exists', return_value=True):
+        with mock.patch("os.path.exists", return_value=True):
             self.assertAgentOK(stop_monitored_copytool(self.ct_id))
 
         self.assertRanAllCommandsInOrder()
 
     def test_configure_should_be_idempotent(self):
         expected_kwargs = dict(
-            index = self.ct_index,
-            bin_path = self.ct_bin_path,
-            filesystem = self.ct_filesystem,
-            mountpoint = self.ct_mountpoint,
-            archive_number = self.ct_archive,
-            hsm_arguments = self.ct_arguments
+            index=self.ct_index,
+            bin_path=self.ct_bin_path,
+            filesystem=self.ct_filesystem,
+            mountpoint=self.ct_mountpoint,
+            archive_number=self.ct_archive,
+            hsm_arguments=self.ct_arguments,
         )
-        with mock.patch('chroma_agent.action_plugins.manage_copytool.update_copytool') as patched_update_copytool:
+        with mock.patch(
+            "chroma_agent.action_plugins.manage_copytool.update_copytool"
+        ) as patched_update_copytool:
             self._configure_copytool()
             patched_update_copytool.assert_called_with(self.ct_id, **expected_kwargs)
 
-    @mock.patch('chroma_agent.action_plugins.manage_copytool.stop_monitored_copytool')
+    @mock.patch("chroma_agent.action_plugins.manage_copytool.stop_monitored_copytool")
     def test_unconfigure_copytool(self, stop_monitored_copytool):
         # NB: configure_copytool is implicitly tested numerous times as
         # part of setUp(). Kind of hacky but whatever.
         unconfigure_copytool(self.ct_id)
         stop_monitored_copytool.assert_called_with(self.ct_id)
 
-    @mock.patch('chroma_agent.action_plugins.manage_copytool.stop_monitored_copytool')
-    @mock.patch('chroma_agent.action_plugins.manage_copytool.start_monitored_copytool')
+    @mock.patch("chroma_agent.action_plugins.manage_copytool.stop_monitored_copytool")
+    @mock.patch("chroma_agent.action_plugins.manage_copytool.start_monitored_copytool")
     def test_update_copytool(self, start_monitored_copytool, stop_monitored_copytool):
         update_copytool(self.ct_id, archive_number=2)
 
         stop_monitored_copytool.assert_called_with(self.ct_id)
 
-        self.assertEquals(self.mock_config.get('copytools', self.ct_id)['archive_number'], 2)
+        self.assertEquals(
+            self.mock_config.get("copytools", self.ct_id)["archive_number"], 2
+        )
 
         start_monitored_copytool.assert_called_with(self.ct_id)
 
     def test_list_copytools(self):
-        self.assertDictEqual(list_copytools(), {'raw_result': self.ct_id})
+        self.assertDictEqual(list_copytools(), {"raw_result": self.ct_id})

--- a/tests/actions_plugins/test_manage_network.py
+++ b/tests/actions_plugins/test_manage_network.py
@@ -6,18 +6,18 @@ from chroma_agent.action_plugins.manage_network import open_firewall, close_fire
 
 
 class TestManageNetworking(unittest.TestCase):
-    @mock.patch('iml_common.lib.firewall_control.FirewallControl.create')
+    @mock.patch("iml_common.lib.firewall_control.FirewallControl.create")
     def test_open_firewall_port(self, mock_firewall_control):
-        open_firewall(1, 2, 'bob', 'uncle', False)
-        open_firewall(3, 4, 'sid', 'vicious', True)
+        open_firewall(1, 2, "bob", "uncle", False)
+        open_firewall(3, 4, "sid", "vicious", True)
 
-        mock_firewall_control.assert_has_calls(mock.call(1, 'bob', 'uncle', False, 2))
-        mock_firewall_control.assert_has_calls(mock.call(3, 'sid', 'vicious', True, 4))
+        mock_firewall_control.assert_has_calls(mock.call(1, "bob", "uncle", False, 2))
+        mock_firewall_control.assert_has_calls(mock.call(3, "sid", "vicious", True, 4))
 
-    @mock.patch('iml_common.lib.firewall_control.FirewallControl.create')
+    @mock.patch("iml_common.lib.firewall_control.FirewallControl.create")
     def test_close_firewall_port(self, mock_firewall_control):
-        close_firewall(1, 2, 'bob', 'uncle', False)
-        close_firewall(3, 4, 'sid', 'vicious', True)
+        close_firewall(1, 2, "bob", "uncle", False)
+        close_firewall(3, 4, "sid", "vicious", True)
 
-        mock_firewall_control.assert_has_calls(mock.call(1, 'bob', 'uncle', False, 2))
-        mock_firewall_control.assert_has_calls(mock.call(3, 'sid', 'vicious', True, 4))
+        mock_firewall_control.assert_has_calls(mock.call(1, "bob", "uncle", False, 2))
+        mock_firewall_control.assert_has_calls(mock.call(3, "sid", "vicious", True, 4))

--- a/tests/actions_plugins/test_manage_target.py
+++ b/tests/actions_plugins/test_manage_target.py
@@ -3,7 +3,10 @@ from django.utils import unittest
 
 from iml_common.blockdevices.blockdevice import BlockDevice
 from iml_common.blockdevices.blockdevice_zfs import BlockDeviceZfs
-from iml_common.test.command_capture_testcase import CommandCaptureTestCase, CommandCaptureCommand
+from iml_common.test.command_capture_testcase import (
+    CommandCaptureTestCase,
+    CommandCaptureCommand,
+)
 from tests.lib.agent_unit_testcase import AgentUnitTestCase
 
 
@@ -12,27 +15,25 @@ class TestWriteconfTarget(CommandCaptureTestCase):
         super(TestWriteconfTarget, self).setUp()
 
         from chroma_agent.action_plugins import manage_targets
+
         self.manage_targets = manage_targets
 
     def test_mdt_tunefs(self):
-        self.add_command(('tunefs.lustre', '--mdt', '/dev/foo'))
+        self.add_command(("tunefs.lustre", "--mdt", "/dev/foo"))
 
-        self.manage_targets.writeconf_target(device='/dev/foo',
-                                             target_types=['mdt'])
+        self.manage_targets.writeconf_target(device="/dev/foo", target_types=["mdt"])
         self.assertRanAllCommands()
 
     def test_mgs_tunefs(self):
         self.add_command(("tunefs.lustre", "--mgs", "/dev/foo"))
 
-        self.manage_targets.writeconf_target(device='/dev/foo',
-                                             target_types=['mgs'])
+        self.manage_targets.writeconf_target(device="/dev/foo", target_types=["mgs"])
         self.assertRanAllCommands()
 
     def test_ost_tunefs(self):
         self.add_command(("tunefs.lustre", "--ost", "/dev/foo"))
 
-        self.manage_targets.writeconf_target(device='/dev/foo',
-                                             target_types=['ost'])
+        self.manage_targets.writeconf_target(device="/dev/foo", target_types=["ost"])
         self.assertRanAllCommands()
 
     # this test does double-duty in testing tuple opts and also
@@ -40,59 +41,93 @@ class TestWriteconfTarget(CommandCaptureTestCase):
     def test_tuple_opts(self):
         self.add_command(("tunefs.lustre", "--mgs", "--mdt", "/dev/foo"))
 
-        self.manage_targets.writeconf_target(device='/dev/foo',
-                                             target_types=['mgs', 'mdt'])
+        self.manage_targets.writeconf_target(
+            device="/dev/foo", target_types=["mgs", "mdt"]
+        )
         self.assertRanAllCommands()
 
     def test_dict_opts(self):
-        self.add_command(("tunefs.lustre", "--param", "foo=bar", "--param", "baz=qux thud", "/dev/foo"))
+        self.add_command(
+            (
+                "tunefs.lustre",
+                "--param",
+                "foo=bar",
+                "--param",
+                "baz=qux thud",
+                "/dev/foo",
+            )
+        )
 
-        self.manage_targets.writeconf_target(device='/dev/foo',
-                                             param={'foo': 'bar', 'baz': 'qux thud'})
+        self.manage_targets.writeconf_target(
+            device="/dev/foo", param={"foo": "bar", "baz": "qux thud"}
+        )
         self.assertRanAllCommands()
 
     def test_flag_opts(self):
         self.add_command(("tunefs.lustre", "--dryrun", "/dev/foo"))
 
-        self.manage_targets.writeconf_target(device='/dev/foo',
-                                             dryrun=True)
+        self.manage_targets.writeconf_target(device="/dev/foo", dryrun=True)
         self.assertRanAllCommands()
 
     def test_other_opts(self):
-        self.add_command(("tunefs.lustre", "--index=42", "--mountfsoptions=-x 30 --y --z=83", "/dev/foo"))
+        self.add_command(
+            (
+                "tunefs.lustre",
+                "--index=42",
+                "--mountfsoptions=-x 30 --y --z=83",
+                "/dev/foo",
+            )
+        )
 
-        self.manage_targets.writeconf_target(device='/dev/foo',
-                                             index='42', mountfsoptions='-x 30 --y --z=83')
+        self.manage_targets.writeconf_target(
+            device="/dev/foo", index="42", mountfsoptions="-x 30 --y --z=83"
+        )
         self.assertRanAllCommands()
 
     def test_mgsnode_multiple_nids(self):
-        self.add_command(("tunefs.lustre", "--erase-params", "--mgsnode=1.2.3.4@tcp,4.3.2.1@tcp1",
-                          "--mgsnode=1.2.3.5@tcp0,4.3.2.2@tcp1", "--writeconf", "/dev/foo"))
+        self.add_command(
+            (
+                "tunefs.lustre",
+                "--erase-params",
+                "--mgsnode=1.2.3.4@tcp,4.3.2.1@tcp1",
+                "--mgsnode=1.2.3.5@tcp0,4.3.2.2@tcp1",
+                "--writeconf",
+                "/dev/foo",
+            )
+        )
 
-        self.manage_targets.writeconf_target(device='/dev/foo',
-                                             writeconf=True,
-                                             erase_params=True,
-                                             mgsnode=[['1.2.3.4@tcp', '4.3.2.1@tcp1'],
-                                                      ['1.2.3.5@tcp0', '4.3.2.2@tcp1']])
+        self.manage_targets.writeconf_target(
+            device="/dev/foo",
+            writeconf=True,
+            erase_params=True,
+            mgsnode=[["1.2.3.4@tcp", "4.3.2.1@tcp1"], ["1.2.3.5@tcp0", "4.3.2.2@tcp1"]],
+        )
         self.assertRanAllCommands()
 
     def test_unknown_opt(self):
-        self.assertRaises(TypeError, self.manage_targets.writeconf_target, unknown='whatever')
+        self.assertRaises(
+            TypeError, self.manage_targets.writeconf_target, unknown="whatever"
+        )
 
 
 class TestFormatTarget(CommandCaptureTestCase):
-    block_device_list = [BlockDevice('linux', '/dev/foo'),
-                         BlockDevice('zfs', 'lustre1')]
+    block_device_list = [
+        BlockDevice("linux", "/dev/foo"),
+        BlockDevice("zfs", "lustre1"),
+    ]
 
     def setUp(self):
         super(TestFormatTarget, self).setUp()
 
         from chroma_agent.action_plugins import manage_targets
+
         self.manage_targets = manage_targets
         mock.patch(
-            'iml_common.blockdevices.blockdevice_zfs.BlockDeviceZfs._check_module').start()
+            "iml_common.blockdevices.blockdevice_zfs.BlockDeviceZfs._check_module"
+        ).start()
         mock.patch(
-            'iml_common.blockdevices.blockdevice_linux.BlockDeviceLinux._check_module').start()
+            "iml_common.blockdevices.blockdevice_linux.BlockDeviceLinux._check_module"
+        ).start()
 
         self.addCleanup(mock.patch.stopall)
 
@@ -101,9 +136,9 @@ class TestFormatTarget(CommandCaptureTestCase):
         method was added and so rather than remove the method I've made it return the same value for both cases and
         perhaps in the future it will be called into use again
         """
-        if block_device.device_type == 'linux':
+        if block_device.device_type == "linux":
             return block_device.device_path
-        elif block_device.device_type == 'zfs':
+        elif block_device.device_type == "zfs":
             return "%s/%s" % (block_device.device_path, target_name)
 
         assert "Unknown device type %s" % block_device.device_type
@@ -111,153 +146,229 @@ class TestFormatTarget(CommandCaptureTestCase):
     def _setup_run_exceptions(self, block_device, run_args):
         self._run_command = CommandCaptureCommand(tuple(filter(None, run_args)))
 
-        self.add_commands(CommandCaptureCommand(("/usr/sbin/udevadm", "info", "--path=/module/zfs")),
-                          CommandCaptureCommand(("zpool", "set", "failmode=panic", "lustre1")),
-                          CommandCaptureCommand(("dumpe2fs", "-h", "/dev/foo"),
-                                                stdout="Inode size: 1024\nInode count: 1024\n"),
-                          CommandCaptureCommand(("blkid", "-p", "-o", "value", "-s", "TYPE", "/dev/foo"),
-                                                stdout="%s\n" % block_device.preferred_fstype),
-                          CommandCaptureCommand(("blkid", "-p", "-o", "value", "-s", "UUID", "/dev/foo"),
-                                                stdout="123456789\n"),
-                          CommandCaptureCommand(("zpool", "list", "-H", "-o", "name"),
-                                                stdout='lustre1'),
-                          CommandCaptureCommand(("zfs", "get", "-H", "-o", "value", "guid", "lustre1/OST0000"),
-                                                stdout="9845118046416187754"),
-                          CommandCaptureCommand(("zfs", "get", "-H", "-o", "value", "guid", "lustre1/MDT0000"),
-                                                stdout="9845118046416187755"),
-                          CommandCaptureCommand(("zfs", "get", "-H", "-o", "value", "guid", "lustre1/MGS0000"),
-                                                stdout="9845118046416187756"),
-                          CommandCaptureCommand(("zfs", "list", "-H", "-o", "name", "-r", "lustre1")),
-                          CommandCaptureCommand(("modprobe", "%s" % block_device.preferred_fstype)),
-                          CommandCaptureCommand(("modprobe", "osd_%s" % block_device.preferred_fstype)),
-                          self._run_command)
+        self.add_commands(
+            CommandCaptureCommand(("/usr/sbin/udevadm", "info", "--path=/module/zfs")),
+            CommandCaptureCommand(("zpool", "set", "failmode=panic", "lustre1")),
+            CommandCaptureCommand(
+                ("dumpe2fs", "-h", "/dev/foo"),
+                stdout="Inode size: 1024\nInode count: 1024\n",
+            ),
+            CommandCaptureCommand(
+                ("blkid", "-p", "-o", "value", "-s", "TYPE", "/dev/foo"),
+                stdout="%s\n" % block_device.preferred_fstype,
+            ),
+            CommandCaptureCommand(
+                ("blkid", "-p", "-o", "value", "-s", "UUID", "/dev/foo"),
+                stdout="123456789\n",
+            ),
+            CommandCaptureCommand(
+                ("zpool", "list", "-H", "-o", "name"), stdout="lustre1"
+            ),
+            CommandCaptureCommand(
+                ("zfs", "get", "-H", "-o", "value", "guid", "lustre1/OST0000"),
+                stdout="9845118046416187754",
+            ),
+            CommandCaptureCommand(
+                ("zfs", "get", "-H", "-o", "value", "guid", "lustre1/MDT0000"),
+                stdout="9845118046416187755",
+            ),
+            CommandCaptureCommand(
+                ("zfs", "get", "-H", "-o", "value", "guid", "lustre1/MGS0000"),
+                stdout="9845118046416187756",
+            ),
+            CommandCaptureCommand(("zfs", "list", "-H", "-o", "name", "-r", "lustre1")),
+            CommandCaptureCommand(("modprobe", "%s" % block_device.preferred_fstype)),
+            CommandCaptureCommand(
+                ("modprobe", "osd_%s" % block_device.preferred_fstype)
+            ),
+            self._run_command,
+        )
 
     def test_mdt_mkfs(self):
         for block_device in self.block_device_list:
-            self._setup_run_exceptions(block_device,
-                                       ("mkfs.lustre",
-                                        "--mdt",
-                                        "--backfstype=%s" % block_device.preferred_fstype,
-                                        '--mkfsoptions="mountpoint=none"' if block_device.device_type == 'zfs' else '',
-                                        self._mkfs_path(block_device, "MDT0000")))
+            self._setup_run_exceptions(
+                block_device,
+                (
+                    "mkfs.lustre",
+                    "--mdt",
+                    "--backfstype=%s" % block_device.preferred_fstype,
+                    '--mkfsoptions="mountpoint=none"'
+                    if block_device.device_type == "zfs"
+                    else "",
+                    self._mkfs_path(block_device, "MDT0000"),
+                ),
+            )
 
-            self.manage_targets.format_target(device=block_device.device_path,
-                                              device_type=block_device.device_type,
-                                              target_name="MDT0000",
-                                              backfstype=block_device.preferred_fstype,
-                                              target_types=['mdt'])
+            self.manage_targets.format_target(
+                device=block_device.device_path,
+                device_type=block_device.device_type,
+                target_name="MDT0000",
+                backfstype=block_device.preferred_fstype,
+                target_types=["mdt"],
+            )
 
             self.assertRanCommand(self._run_command)
 
     def test_mgs_mkfs(self):
         for block_device in self.block_device_list:
-            self._setup_run_exceptions(block_device,
-                                       ("mkfs.lustre",
-                                        "--mgs",
-                                        "--backfstype=%s" % block_device.preferred_fstype,
-                                        '--mkfsoptions="mountpoint=none"' if block_device.device_type == 'zfs' else '',
-                                        self._mkfs_path(block_device, "MGS0000")))
+            self._setup_run_exceptions(
+                block_device,
+                (
+                    "mkfs.lustre",
+                    "--mgs",
+                    "--backfstype=%s" % block_device.preferred_fstype,
+                    '--mkfsoptions="mountpoint=none"'
+                    if block_device.device_type == "zfs"
+                    else "",
+                    self._mkfs_path(block_device, "MGS0000"),
+                ),
+            )
 
-            self.manage_targets.format_target(device=block_device.device_path,
-                                              device_type=block_device.device_type,
-                                              target_name="MGS0000",
-                                              backfstype=block_device.preferred_fstype,
-                                              target_types=['mgs'])
+            self.manage_targets.format_target(
+                device=block_device.device_path,
+                device_type=block_device.device_type,
+                target_name="MGS0000",
+                backfstype=block_device.preferred_fstype,
+                target_types=["mgs"],
+            )
 
             self.assertRanCommand(self._run_command)
 
     def test_ost_mkfs(self):
         for block_device in self.block_device_list:
-            self._setup_run_exceptions(block_device,
-                                       ("mkfs.lustre",
-                                        "--ost",
-                                        "--backfstype=%s" % block_device.preferred_fstype,
-                                        '--mkfsoptions="mountpoint=none"' if block_device.device_type == 'zfs' else '',
-                                        self._mkfs_path(block_device, "MDT0000")))
+            self._setup_run_exceptions(
+                block_device,
+                (
+                    "mkfs.lustre",
+                    "--ost",
+                    "--backfstype=%s" % block_device.preferred_fstype,
+                    '--mkfsoptions="mountpoint=none"'
+                    if block_device.device_type == "zfs"
+                    else "",
+                    self._mkfs_path(block_device, "MDT0000"),
+                ),
+            )
 
-            self.manage_targets.format_target(device=block_device.device_path,
-                                              device_type=block_device.device_type,
-                                              target_name="MDT0000",
-                                              backfstype=block_device.preferred_fstype,
-                                              target_types=['ost'])
+            self.manage_targets.format_target(
+                device=block_device.device_path,
+                device_type=block_device.device_type,
+                target_name="MDT0000",
+                backfstype=block_device.preferred_fstype,
+                target_types=["ost"],
+            )
 
             self.assertRanCommand(self._run_command)
 
     def test_single_mgs_one_nid(self):
         for block_device in self.block_device_list:
-            self._setup_run_exceptions(block_device,
-                                       ("mkfs.lustre",
-                                        "--ost",
-                                        "--mgsnode=1.2.3.4@tcp",
-                                        "--backfstype=%s" % block_device.preferred_fstype,
-                                        '--mkfsoptions="mountpoint=none"' if block_device.device_type == 'zfs' else '',
-                                        self._mkfs_path(block_device, "OST0000")))
+            self._setup_run_exceptions(
+                block_device,
+                (
+                    "mkfs.lustre",
+                    "--ost",
+                    "--mgsnode=1.2.3.4@tcp",
+                    "--backfstype=%s" % block_device.preferred_fstype,
+                    '--mkfsoptions="mountpoint=none"'
+                    if block_device.device_type == "zfs"
+                    else "",
+                    self._mkfs_path(block_device, "OST0000"),
+                ),
+            )
 
-            self.manage_targets.format_target(device=block_device.device_path,
-                                              device_type=block_device.device_type,
-                                              target_name="OST0000",
-                                              backfstype=block_device.preferred_fstype,
-                                              target_types=['ost'],
-                                              mgsnode=[['1.2.3.4@tcp']])
+            self.manage_targets.format_target(
+                device=block_device.device_path,
+                device_type=block_device.device_type,
+                target_name="OST0000",
+                backfstype=block_device.preferred_fstype,
+                target_types=["ost"],
+                mgsnode=[["1.2.3.4@tcp"]],
+            )
 
             self.assertRanCommand(self._run_command)
 
     def test_mgs_pair_one_nid(self):
         for block_device in self.block_device_list:
-            self._setup_run_exceptions(block_device,
-                                       ("mkfs.lustre", "--ost",
-                                        "--mgsnode=1.2.3.4@tcp",
-                                        "--mgsnode=1.2.3.5@tcp",
-                                        "--backfstype=%s" % block_device.preferred_fstype,
-                                        '--mkfsoptions="mountpoint=none"' if block_device.device_type == 'zfs' else '',
-                                        self._mkfs_path(block_device, "OST0000")))
+            self._setup_run_exceptions(
+                block_device,
+                (
+                    "mkfs.lustre",
+                    "--ost",
+                    "--mgsnode=1.2.3.4@tcp",
+                    "--mgsnode=1.2.3.5@tcp",
+                    "--backfstype=%s" % block_device.preferred_fstype,
+                    '--mkfsoptions="mountpoint=none"'
+                    if block_device.device_type == "zfs"
+                    else "",
+                    self._mkfs_path(block_device, "OST0000"),
+                ),
+            )
 
-            self.manage_targets.format_target(device=block_device.device_path,
-                                              target_types=['ost'],
-                                              target_name="OST0000",
-                                              backfstype=block_device.preferred_fstype,
-                                              device_type=block_device.device_type,
-                                              mgsnode=[['1.2.3.4@tcp'], ['1.2.3.5@tcp']])
+            self.manage_targets.format_target(
+                device=block_device.device_path,
+                target_types=["ost"],
+                target_name="OST0000",
+                backfstype=block_device.preferred_fstype,
+                device_type=block_device.device_type,
+                mgsnode=[["1.2.3.4@tcp"], ["1.2.3.5@tcp"]],
+            )
 
             self.assertRanCommand(self._run_command)
 
     def test_single_mgs_multiple_nids(self):
         for block_device in self.block_device_list:
-            self._setup_run_exceptions(block_device,
-                                       ("mkfs.lustre",
-                                        "--ost",
-                                        "--mgsnode=1.2.3.4@tcp0,4.3.2.1@tcp1",
-                                        "--backfstype=%s" % block_device.preferred_fstype,
-                                        '--mkfsoptions="mountpoint=none"' if block_device.device_type == 'zfs' else '',
-                                        self._mkfs_path(block_device, "OST0000")))
+            self._setup_run_exceptions(
+                block_device,
+                (
+                    "mkfs.lustre",
+                    "--ost",
+                    "--mgsnode=1.2.3.4@tcp0,4.3.2.1@tcp1",
+                    "--backfstype=%s" % block_device.preferred_fstype,
+                    '--mkfsoptions="mountpoint=none"'
+                    if block_device.device_type == "zfs"
+                    else "",
+                    self._mkfs_path(block_device, "OST0000"),
+                ),
+            )
 
-            self.manage_targets.format_target(device=block_device.device_path,
-                                              target_types=['ost'],
-                                              target_name="OST0000",
-                                              backfstype=block_device.preferred_fstype,
-                                              device_type=block_device.device_type,
-                                              mgsnode=[['1.2.3.4@tcp0', '4.3.2.1@tcp1']])
+            self.manage_targets.format_target(
+                device=block_device.device_path,
+                target_types=["ost"],
+                target_name="OST0000",
+                backfstype=block_device.preferred_fstype,
+                device_type=block_device.device_type,
+                mgsnode=[["1.2.3.4@tcp0", "4.3.2.1@tcp1"]],
+            )
 
             self.assertRanCommand(self._run_command)
 
     def test_mgs_pair_multiple_nids(self):
         for block_device in self.block_device_list:
-            self._setup_run_exceptions(block_device,
-                                       ("mkfs.lustre",
-                                        "--ost",
-                                        "--mgsnode=1.2.3.4@tcp0,4.3.2.1@tcp1",
-                                        "--mgsnode=1.2.3.5@tcp0,4.3.2.2@tcp1",
-                                        "--backfstype=%s" % block_device.preferred_fstype,
-                                        '--mkfsoptions="mountpoint=none"' if block_device.device_type == 'zfs' else '',
-                                        self._mkfs_path(block_device, "OST0000")))
+            self._setup_run_exceptions(
+                block_device,
+                (
+                    "mkfs.lustre",
+                    "--ost",
+                    "--mgsnode=1.2.3.4@tcp0,4.3.2.1@tcp1",
+                    "--mgsnode=1.2.3.5@tcp0,4.3.2.2@tcp1",
+                    "--backfstype=%s" % block_device.preferred_fstype,
+                    '--mkfsoptions="mountpoint=none"'
+                    if block_device.device_type == "zfs"
+                    else "",
+                    self._mkfs_path(block_device, "OST0000"),
+                ),
+            )
 
-            self.manage_targets.format_target(device=block_device.device_path,
-                                              target_name="OST0000",
-                                              backfstype=block_device.preferred_fstype,
-                                              target_types=['ost'],
-                                              device_type=block_device.device_type,
-                                              mgsnode=[['1.2.3.4@tcp0', '4.3.2.1@tcp1'],
-                                                       ['1.2.3.5@tcp0', '4.3.2.2@tcp1']])
+            self.manage_targets.format_target(
+                device=block_device.device_path,
+                target_name="OST0000",
+                backfstype=block_device.preferred_fstype,
+                target_types=["ost"],
+                device_type=block_device.device_type,
+                mgsnode=[
+                    ["1.2.3.4@tcp0", "4.3.2.1@tcp1"],
+                    ["1.2.3.5@tcp0", "4.3.2.2@tcp1"],
+                ],
+            )
 
             self.assertRanCommand(self._run_command)
 
@@ -265,97 +376,149 @@ class TestFormatTarget(CommandCaptureTestCase):
     # the multiple target_types special case
     def test_tuple_opts(self):
         for block_device in self.block_device_list:
-            self._setup_run_exceptions(block_device,
-                                       ("mkfs.lustre",
-                                        "--mgs",
-                                        "--mdt", "--backfstype=%s" % block_device.preferred_fstype,
-                                        '--mkfsoptions="mountpoint=none"' if block_device.device_type == 'zfs' else '',
-                                        self._mkfs_path(block_device, "MGS0000")))
+            self._setup_run_exceptions(
+                block_device,
+                (
+                    "mkfs.lustre",
+                    "--mgs",
+                    "--mdt",
+                    "--backfstype=%s" % block_device.preferred_fstype,
+                    '--mkfsoptions="mountpoint=none"'
+                    if block_device.device_type == "zfs"
+                    else "",
+                    self._mkfs_path(block_device, "MGS0000"),
+                ),
+            )
 
-            self.manage_targets.format_target(device=block_device.device_path,
-                                              device_type=block_device.device_type,
-                                              target_name="MGS0000",
-                                              backfstype=block_device.preferred_fstype,
-                                              target_types=['mgs', 'mdt'])
+            self.manage_targets.format_target(
+                device=block_device.device_path,
+                device_type=block_device.device_type,
+                target_name="MGS0000",
+                backfstype=block_device.preferred_fstype,
+                target_types=["mgs", "mdt"],
+            )
 
             self.assertRanCommand(self._run_command)
 
     def test_dict_opts(self):
         for block_device in self.block_device_list:
-            self._setup_run_exceptions(block_device,
-                                       ("mkfs.lustre",
-                                        "--param",
-                                        "foo=bar",
-                                        "--param",
-                                        "baz=qux thud",
-                                        "--backfstype=%s" % block_device.preferred_fstype,
-                                        '--mkfsoptions="mountpoint=none"' if block_device.device_type == 'zfs' else '',
-                                        self._mkfs_path(block_device, "MGS0000")))
+            self._setup_run_exceptions(
+                block_device,
+                (
+                    "mkfs.lustre",
+                    "--param",
+                    "foo=bar",
+                    "--param",
+                    "baz=qux thud",
+                    "--backfstype=%s" % block_device.preferred_fstype,
+                    '--mkfsoptions="mountpoint=none"'
+                    if block_device.device_type == "zfs"
+                    else "",
+                    self._mkfs_path(block_device, "MGS0000"),
+                ),
+            )
 
-            self.manage_targets.format_target(device=block_device.device_path,
-                                              device_type=block_device.device_type,
-                                              target_name="MGS0000",
-                                              backfstype=block_device.preferred_fstype,
-                                              param={'foo': 'bar', 'baz': 'qux thud'})
+            self.manage_targets.format_target(
+                device=block_device.device_path,
+                device_type=block_device.device_type,
+                target_name="MGS0000",
+                backfstype=block_device.preferred_fstype,
+                param={"foo": "bar", "baz": "qux thud"},
+            )
 
             self.assertRanCommand(self._run_command)
 
     def test_flag_opts(self):
         for block_device in self.block_device_list:
-            self._setup_run_exceptions(block_device,
-                                       ("mkfs.lustre",
-                                        "--dryrun",
-                                        "--backfstype=%s" % block_device.preferred_fstype,
-                                        '--mkfsoptions="mountpoint=none"' if block_device.device_type == 'zfs' else '',
-                                        self._mkfs_path(block_device, "MGS0000")))
+            self._setup_run_exceptions(
+                block_device,
+                (
+                    "mkfs.lustre",
+                    "--dryrun",
+                    "--backfstype=%s" % block_device.preferred_fstype,
+                    '--mkfsoptions="mountpoint=none"'
+                    if block_device.device_type == "zfs"
+                    else "",
+                    self._mkfs_path(block_device, "MGS0000"),
+                ),
+            )
 
-            self.manage_targets.format_target(device=block_device.device_path,
-                                              device_type=block_device.device_type,
-                                              target_name="MGS0000",
-                                              backfstype=block_device.preferred_fstype,
-                                              dryrun=True)
+            self.manage_targets.format_target(
+                device=block_device.device_path,
+                device_type=block_device.device_type,
+                target_name="MGS0000",
+                backfstype=block_device.preferred_fstype,
+                dryrun=True,
+            )
 
             self.assertRanCommand(self._run_command)
 
     def test_zero_opt(self):
         for block_device in self.block_device_list:
-            self._setup_run_exceptions(block_device,
-                                       ("mkfs.lustre",
-                                        "--index=0",
-                                        '--mkfsoptions=%s' % (
-                                        '-x 30 --y --z=83' if block_device.device_type == 'linux' else '"mountpoint=none"'),
-                                        "--backfstype=%s" % block_device.preferred_fstype,
-                                        self._mkfs_path(block_device, "MGS0000")))
+            self._setup_run_exceptions(
+                block_device,
+                (
+                    "mkfs.lustre",
+                    "--index=0",
+                    "--mkfsoptions=%s"
+                    % (
+                        "-x 30 --y --z=83"
+                        if block_device.device_type == "linux"
+                        else '"mountpoint=none"'
+                    ),
+                    "--backfstype=%s" % block_device.preferred_fstype,
+                    self._mkfs_path(block_device, "MGS0000"),
+                ),
+            )
 
-            self.manage_targets.format_target(device=block_device.device_path,
-                                              device_type=block_device.device_type,
-                                              target_name="MGS0000",
-                                              backfstype=block_device.preferred_fstype,
-                                              index=0,
-                                              mkfsoptions='-x 30 --y --z=83' if block_device.device_type == 'linux' else '"mountpoint=none"')
+            self.manage_targets.format_target(
+                device=block_device.device_path,
+                device_type=block_device.device_type,
+                target_name="MGS0000",
+                backfstype=block_device.preferred_fstype,
+                index=0,
+                mkfsoptions="-x 30 --y --z=83"
+                if block_device.device_type == "linux"
+                else '"mountpoint=none"',
+            )
             self.assertRanCommand(self._run_command)
 
     def test_other_opts(self):
         for block_device in self.block_device_list:
-            self._setup_run_exceptions(block_device,
-                                       ("mkfs.lustre",
-                                        "--index=42",
-                                        '--mkfsoptions=%s' % (
-                                        '-x 30 --y --z=83' if block_device.device_type == 'linux' else '"mountpoint=none"'),
-                                        "--backfstype=%s" % block_device.preferred_fstype,
-                                        self._mkfs_path(block_device, "MGS0000")))
+            self._setup_run_exceptions(
+                block_device,
+                (
+                    "mkfs.lustre",
+                    "--index=42",
+                    "--mkfsoptions=%s"
+                    % (
+                        "-x 30 --y --z=83"
+                        if block_device.device_type == "linux"
+                        else '"mountpoint=none"'
+                    ),
+                    "--backfstype=%s" % block_device.preferred_fstype,
+                    self._mkfs_path(block_device, "MGS0000"),
+                ),
+            )
 
-            self.manage_targets.format_target(device=block_device.device_path,
-                                              device_type=block_device.device_type,
-                                              target_name="MGS0000",
-                                              backfstype=block_device.preferred_fstype,
-                                              index=42,
-                                              mkfsoptions='-x 30 --y --z=83' if block_device.device_type == 'linux' else '"mountpoint=none"')
+            self.manage_targets.format_target(
+                device=block_device.device_path,
+                device_type=block_device.device_type,
+                target_name="MGS0000",
+                backfstype=block_device.preferred_fstype,
+                index=42,
+                mkfsoptions="-x 30 --y --z=83"
+                if block_device.device_type == "linux"
+                else '"mountpoint=none"',
+            )
 
             self.assertRanCommand(self._run_command)
 
     def test_unknown_opt(self):
-        self.assertRaises(TypeError, self.manage_targets.format_target, unknown='whatever')
+        self.assertRaises(
+            TypeError, self.manage_targets.format_target, unknown="whatever"
+        )
+
 
 class TestXMLParsing(unittest.TestCase):
     xml_crm_mon = """<?xml version="1.0"?>
@@ -403,59 +566,91 @@ class TestXMLParsing(unittest.TestCase):
 
     def test_get_resource_locations(self):
         from chroma_agent.action_plugins import manage_targets
-        self.assertDictEqual(manage_targets._get_resource_locations(self.xml_crm_mon),
-                             {'fs1-MDT0000_6cc06e': 'iml-mds01.iml',
-                              'fs1-MDT0001_41549d-zfs': 'iml-mds01.iml',
-                              'fs1-MDT0001_41549d': 'iml-mds01.iml',
-                              'MGS_054510': 'iml-mds02.iml'})
-        
+
+        self.assertDictEqual(
+            manage_targets._get_resource_locations(self.xml_crm_mon),
+            {
+                "fs1-MDT0000_6cc06e": "iml-mds01.iml",
+                "fs1-MDT0001_41549d-zfs": "iml-mds01.iml",
+                "fs1-MDT0001_41549d": "iml-mds01.iml",
+                "MGS_054510": "iml-mds02.iml",
+            },
+        )
+
 
 class TestCheckBlockDevice(CommandCaptureTestCase, AgentUnitTestCase):
     def setUp(self):
         super(TestCheckBlockDevice, self).setUp()
 
         from chroma_agent.action_plugins import manage_targets
+
         self.manage_targets = manage_targets
         mock.patch(
-            'iml_common.blockdevices.blockdevice_zfs.BlockDeviceZfs._check_module').start()
+            "iml_common.blockdevices.blockdevice_zfs.BlockDeviceZfs._check_module"
+        ).start()
         mock.patch(
-            'iml_common.blockdevices.blockdevice_linux.BlockDeviceLinux._check_module').start()
+            "iml_common.blockdevices.blockdevice_linux.BlockDeviceLinux._check_module"
+        ).start()
 
         self.addCleanup(mock.patch.stopall)
 
     def test_occupied_device_ldiskfs(self):
         self.add_commands(
-            CommandCaptureCommand(("blkid", "-p", "-o", "value", "-s", "TYPE", "/dev/sdb"), stdout="ext4\n"))
+            CommandCaptureCommand(
+                ("blkid", "-p", "-o", "value", "-s", "TYPE", "/dev/sdb"),
+                stdout="ext4\n",
+            )
+        )
 
-        self.assertAgentError(self.manage_targets.check_block_device("/dev/sdb", "linux"), "Filesystem found: type 'ext4'")
+        self.assertAgentError(
+            self.manage_targets.check_block_device("/dev/sdb", "linux"),
+            "Filesystem found: type 'ext4'",
+        )
         self.assertRanAllCommands()
 
     def test_mbr_device_ldiskfs(self):
-        self.add_commands(CommandCaptureCommand(("blkid", "-p", "-o", "value", "-s", "TYPE", "/dev/sdb"), stdout="\n"))
+        self.add_commands(
+            CommandCaptureCommand(
+                ("blkid", "-p", "-o", "value", "-s", "TYPE", "/dev/sdb"), stdout="\n"
+            )
+        )
 
         self.assertAgentOK(self.manage_targets.check_block_device("/dev/sdb", "linux"))
         self.assertRanAllCommands()
 
     def test_empty_device_ldiskfs(self):
-        self.add_commands(CommandCaptureCommand(("blkid", "-p", "-o", "value", "-s", "TYPE", "/dev/sdb"), rc=2))
+        self.add_commands(
+            CommandCaptureCommand(
+                ("blkid", "-p", "-o", "value", "-s", "TYPE", "/dev/sdb"), rc=2
+            )
+        )
 
         self.assertAgentOK(self.manage_targets.check_block_device("/dev/sdb", "linux"))
         self.assertRanAllCommands()
 
     def test_occupied_device_zfs(self):
-        self.add_command(("zfs", "list", "-H", "-o", "name", "-r", "pool1"), stdout="pool1\npool1/dataset_1\n")
+        self.add_command(
+            ("zfs", "list", "-H", "-o", "name", "-r", "pool1"),
+            stdout="pool1\npool1/dataset_1\n",
+        )
 
-        self.assertAgentError(self.manage_targets.check_block_device("pool1", "zfs"),
-                              "Dataset 'dataset_1' found on zpool 'pool1'")
+        self.assertAgentError(
+            self.manage_targets.check_block_device("pool1", "zfs"),
+            "Dataset 'dataset_1' found on zpool 'pool1'",
+        )
         self.assertRanAllCommands()
 
     def test_empty_device_zfs(self):
-        self.add_command(("zfs", "list", "-H", "-o", "name", "-r", "pool1"), stdout="pool1\n")
+        self.add_command(
+            ("zfs", "list", "-H", "-o", "name", "-r", "pool1"), stdout="pool1\n"
+        )
 
         self.assertAgentOK(self.manage_targets.check_block_device("pool1", "zfs"))
         self.assertRanAllCommands()
 
-    @unittest.skip('Unimplemented, need to test running check_block_device on a zfs dataset')
+    @unittest.skip(
+        "Unimplemented, need to test running check_block_device on a zfs dataset"
+    )
     def test_dataset_device_zfs(self):
         pass
 
@@ -465,54 +660,71 @@ class TestCheckImportExport(AgentUnitTestCase):
     Test that the correct blockdevice methods are called, implementation of methods tested in
     test_blockdevice_zfs therefore don't repeat command capturing here
     """
-    zpool = 'zpool'
-    zpool_dataset = '%s/dataset' % zpool
+
+    zpool = "zpool"
+    zpool_dataset = "%s/dataset" % zpool
 
     def setUp(self):
         super(TestCheckImportExport, self).setUp()
 
         from chroma_agent.action_plugins import manage_targets
+
         self.manage_targets = manage_targets
 
-        self.patch_init_modules = mock.patch.object(BlockDeviceZfs, '_check_module')
+        self.patch_init_modules = mock.patch.object(BlockDeviceZfs, "_check_module")
         self.patch_init_modules.start()
         self.mock_import_ = mock.Mock(return_value=None)
-        self.patch_import_ = mock.patch.object(BlockDeviceZfs, 'import_', self.mock_import_)
+        self.patch_import_ = mock.patch.object(
+            BlockDeviceZfs, "import_", self.mock_import_
+        )
         self.patch_import_.start()
         self.mock_export = mock.Mock(return_value=None)
-        self.patch_export = mock.patch.object(BlockDeviceZfs, 'export', self.mock_export)
+        self.patch_export = mock.patch.object(
+            BlockDeviceZfs, "export", self.mock_export
+        )
         self.patch_export.start()
 
         self.addCleanup(mock.patch.stopall)
 
     def test_import_device_ldiskfs(self):
         for with_pacemaker in [True, False]:
-            self.assertAgentOK(self.manage_targets.import_target('linux', '/dev/sdb', with_pacemaker))
+            self.assertAgentOK(
+                self.manage_targets.import_target("linux", "/dev/sdb", with_pacemaker)
+            )
 
     def test_export_device_ldiskfs(self):
-        self.assertAgentOK(self.manage_targets.export_target('linux', '/dev/sdb'))
+        self.assertAgentOK(self.manage_targets.export_target("linux", "/dev/sdb"))
 
     def test_import_device_zfs(self):
         for with_pacemaker in [True, False]:
             self.mock_import_.reset_mock()
-            self.assertAgentOK(self.manage_targets.import_target('zfs', self.zpool_dataset, with_pacemaker))
+            self.assertAgentOK(
+                self.manage_targets.import_target(
+                    "zfs", self.zpool_dataset, with_pacemaker
+                )
+            )
             # Force parameter only supplied on import on retry
             self.mock_import_.assert_called_once_with(False)
 
     def test_import_device_zfs_with_pacemaker_force(self):
         """ Verify force is used only on retry when message indicates """
-        self.mock_import_.side_effect = ['import using -f', None]
+        self.mock_import_.side_effect = ["import using -f", None]
 
-        self.assertAgentOK(self.manage_targets.import_target('zfs', self.zpool_dataset, True))
+        self.assertAgentOK(
+            self.manage_targets.import_target("zfs", self.zpool_dataset, True)
+        )
         self.mock_import_.assert_has_calls([mock.call(False), mock.call(True)])
 
     def test_import_device_zfs_with_pacemaker_fail(self):
         """ Verify force is used only on retry when message indicates """
-        self.mock_import_.side_effect = ['no such pool available', None]
+        self.mock_import_.side_effect = ["no such pool available", None]
 
-        self.assertAgentError(self.manage_targets.import_target('zfs', self.zpool_dataset, True), 'no such pool available')
+        self.assertAgentError(
+            self.manage_targets.import_target("zfs", self.zpool_dataset, True),
+            "no such pool available",
+        )
         self.mock_import_.assert_called_once_with(False)
 
     def test_export_device_zfs(self):
-        self.assertAgentOK(self.manage_targets.export_target('zfs', self.zpool_dataset))
+        self.assertAgentOK(self.manage_targets.export_target("zfs", self.zpool_dataset))
         self.mock_export.assert_called_once_with()

--- a/tests/actions_plugins/test_manage_targets.py
+++ b/tests/actions_plugins/test_manage_targets.py
@@ -1,44 +1,88 @@
 import mock
 
 
-from iml_common.test.command_capture_testcase import CommandCaptureTestCase, CommandCaptureCommand
+from iml_common.test.command_capture_testcase import (
+    CommandCaptureTestCase,
+    CommandCaptureCommand,
+)
 
 
 class TestManagePacemaker(CommandCaptureTestCase):
     def setUp(self):
         super(TestManagePacemaker, self).setUp()
 
-        mock.patch('time.sleep').start()
-        mock.patch('chroma_agent.action_plugins.manage_targets.get_resource_locations').start()
+        mock.patch("time.sleep").start()
+        mock.patch(
+            "chroma_agent.action_plugins.manage_targets.get_resource_locations"
+        ).start()
 
-        self.target_disk = 'target_disk'
-        self.target_node = 'target.node.com'
+        self.target_disk = "target_disk"
+        self.target_node = "target.node.com"
 
-        self.add_commands(CommandCaptureCommand(('crm_mon', '-1')),
-                          CommandCaptureCommand(('crm_resource', '--resource', self.target_disk, '--cleanup')),
-                          CommandCaptureCommand(('crm_resource', '--resource', self.target_disk, '--move', '--node', self.target_node)),
-                          CommandCaptureCommand(('crm_resource', '--resource', self.target_disk, '--un-move', '--node', self.target_node)))
+        self.add_commands(
+            CommandCaptureCommand(("crm_mon", "-1")),
+            CommandCaptureCommand(
+                ("crm_resource", "--resource", self.target_disk, "--cleanup")
+            ),
+            CommandCaptureCommand(
+                (
+                    "crm_resource",
+                    "--resource",
+                    self.target_disk,
+                    "--move",
+                    "--node",
+                    self.target_node,
+                )
+            ),
+            CommandCaptureCommand(
+                (
+                    "crm_resource",
+                    "--resource",
+                    self.target_disk,
+                    "--un-move",
+                    "--node",
+                    self.target_node,
+                )
+            ),
+        )
 
     def test__move_target(self):
         from chroma_agent.action_plugins import manage_targets
-        mock.patch('chroma_agent.action_plugins.manage_targets.get_resource_location',
-                   side_effect=[self.target_node]).start()
 
-        self.assertEqual(manage_targets._move_target(self.target_disk, self.target_node), None)
+        mock.patch(
+            "chroma_agent.action_plugins.manage_targets.get_resource_location",
+            side_effect=[self.target_node],
+        ).start()
+
+        self.assertEqual(
+            manage_targets._move_target(self.target_disk, self.target_node), None
+        )
         self.assertRanAllCommandsInOrder()
 
     def test__move_target_retry(self):
         from chroma_agent.action_plugins import manage_targets
-        mock.patch('chroma_agent.action_plugins.manage_targets.get_resource_location',
-                   side_effect=['', '', self.target_node]).start()
 
-        self.assertEqual(manage_targets._move_target(self.target_disk, self.target_node), None)
+        mock.patch(
+            "chroma_agent.action_plugins.manage_targets.get_resource_location",
+            side_effect=["", "", self.target_node],
+        ).start()
+
+        self.assertEqual(
+            manage_targets._move_target(self.target_disk, self.target_node), None
+        )
         self.assertRanAllCommandsInOrder()
 
     def test__move_target_fail(self):
         from chroma_agent.action_plugins import manage_targets
-        mock.patch('chroma_agent.action_plugins.manage_targets.get_resource_location', return_value='').start()
 
-        self.assertEqual(manage_targets._move_target(self.target_disk, self.target_node),
-                         'Failed to move target %s to node %s' % (self.target_disk, self.target_node))
+        mock.patch(
+            "chroma_agent.action_plugins.manage_targets.get_resource_location",
+            return_value="",
+        ).start()
+
+        self.assertEqual(
+            manage_targets._move_target(self.target_disk, self.target_node),
+            "Failed to move target %s to node %s"
+            % (self.target_disk, self.target_node),
+        )
         self.assertRanAllCommandsInOrder()

--- a/tests/actions_plugins/test_plugins.py
+++ b/tests/actions_plugins/test_plugins.py
@@ -4,7 +4,10 @@ from django.utils.unittest import TestCase
 from chroma_agent.plugin_manager import DevicePluginManager, ActionPluginManager
 from chroma_agent.lib.agent_teardown_functions import agent_daemon_teardown_functions
 from chroma_agent.lib.agent_startup_functions import agent_daemon_startup_functions
-from chroma_agent.action_plugins.device_plugin import initialise_block_device_drivers, terminate_block_device_drivers
+from chroma_agent.action_plugins.device_plugin import (
+    initialise_block_device_drivers,
+    terminate_block_device_drivers,
+)
 
 
 class TestDevicePlugins(TestCase):
@@ -13,19 +16,23 @@ class TestDevicePlugins(TestCase):
         self.assertNotEqual(len(DevicePluginManager.get_plugins()), 0)
 
     def test_excluded_plugins(self):
-        self.assertTrue('linux' in DevicePluginManager.get_plugins())
+        self.assertTrue("linux" in DevicePluginManager.get_plugins())
 
-        with patch('chroma_agent.plugin_manager.EXCLUDED_PLUGINS', ['linux']):
-            with patch.object(DevicePluginManager, '_plugins', {}):
-                self.assertTrue('linux' not in DevicePluginManager.get_plugins())
+        with patch("chroma_agent.plugin_manager.EXCLUDED_PLUGINS", ["linux"]):
+            with patch.object(DevicePluginManager, "_plugins", {}):
+                self.assertTrue("linux" not in DevicePluginManager.get_plugins())
 
     def test_initialise_block_device_drivers_called_at_startup(self):
         """Test method is added to list of functions to run on daemon startup."""
-        self.assertTrue(initialise_block_device_drivers in agent_daemon_startup_functions)
+        self.assertTrue(
+            initialise_block_device_drivers in agent_daemon_startup_functions
+        )
 
     def test_terminate_block_device_drivers_called_at_teardown(self):
         """Test method is added to list of functions to run on daemon teardown."""
-        self.assertTrue(terminate_block_device_drivers in agent_daemon_teardown_functions)
+        self.assertTrue(
+            terminate_block_device_drivers in agent_daemon_teardown_functions
+        )
 
 
 class TestActionPlugins(TestCase):

--- a/tests/audit/test_audit.py
+++ b/tests/audit/test_audit.py
@@ -12,27 +12,32 @@ from iml_common.test.command_capture_testcase import CommandCaptureTestCase
 
 class TestAuditScanner(PatchedContextTestCase):
     def setUp(self):
-        tests = os.path.join(os.path.dirname(__file__), '..')
-        self.test_root = os.path.join(tests, "data/lustre_versions/2.9.58_86_g2383a62/mds_mgs")
+        tests = os.path.join(os.path.dirname(__file__), "..")
+        self.test_root = os.path.join(
+            tests, "data/lustre_versions/2.9.58_86_g2383a62/mds_mgs"
+        )
         super(TestAuditScanner, self).setUp()
 
     def test_audit_scanner(self):
         """chroma_agent.device_plugins.audit.local_audit_classes() should return a list of classes."""
-        list = [cls for cls in
-                chroma_agent.device_plugins.audit.local_audit_classes()]
+        list = [cls for cls in chroma_agent.device_plugins.audit.local_audit_classes()]
         self.assertEqual(list, [LnetAudit, MdtAudit, MgsAudit, NodeAudit])
 
 
 class TestLocalAudit(PatchedContextTestCase):
     def setUp(self):
-        tests = os.path.join(os.path.dirname(__file__), '..')
-        self.test_root = os.path.join(tests, "data/lustre_versions/2.9.58_86_g2383a62/mds_mgs")
+        tests = os.path.join(os.path.dirname(__file__), "..")
+        self.test_root = os.path.join(
+            tests, "data/lustre_versions/2.9.58_86_g2383a62/mds_mgs"
+        )
         super(TestLocalAudit, self).setUp()
         self.audit = LocalAudit()
 
     def test_localaudit_audit_classes(self):
         """LocalAudit.audit_classes() should return a list of classes."""
-        self.assertEqual(self.audit.audit_classes(), [LnetAudit, MdtAudit, MgsAudit, NodeAudit])
+        self.assertEqual(
+            self.audit.audit_classes(), [LnetAudit, MdtAudit, MgsAudit, NodeAudit]
+        )
 
 
 class TestLocalAuditProperties(CommandCaptureTestCase):
@@ -40,27 +45,37 @@ class TestLocalAuditProperties(CommandCaptureTestCase):
         super(TestLocalAuditProperties, self).setUp()
         self.node_audit = NodeAudit()
 
-        mock.patch('platform.linux_distribution', return_value = ('Smarty', '2.2')).start()
-        mock.patch('platform.python_version_tuple', return_value = (1, 2, 3)).start()
-        mock.patch('platform.release', return_value = 'Bazinga').start()
+        mock.patch(
+            "platform.linux_distribution", return_value=("Smarty", "2.2")
+        ).start()
+        mock.patch("platform.python_version_tuple", return_value=(1, 2, 3)).start()
+        mock.patch("platform.release", return_value="Bazinga").start()
 
         self.addCleanup(mock.patch.stopall)
 
     def test_zfs_property_installed(self):
-        self.add_command(('which', 'zfs'), stdout="/sbin/zfs")
-        self.assertEqual(self.node_audit.properties()['zfs_installed'], True)
+        self.add_command(("which", "zfs"), stdout="/sbin/zfs")
+        self.assertEqual(self.node_audit.properties()["zfs_installed"], True)
 
     def test_zfs_property_not_installed(self):
-        self.add_command(('which', 'zfs'), rc=1, stderr="which: no zfs in (/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin)")
-        self.assertEqual(self.node_audit.properties()['zfs_installed'], False)
+        self.add_command(
+            ("which", "zfs"),
+            rc=1,
+            stderr="which: no zfs in (/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin)",
+        )
+        self.assertEqual(self.node_audit.properties()["zfs_installed"], False)
 
     def test_platform_values(self):
-        self.add_command(('which', 'zfs'), rc=1, stderr="which: no zfs in (/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin)")
+        self.add_command(
+            ("which", "zfs"),
+            rc=1,
+            stderr="which: no zfs in (/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin)",
+        )
 
         properties = self.node_audit.properties()
 
-        self.assertEqual(properties['distro'], 'Smarty')
-        self.assertEqual(properties['distro_version'], 2.2)
-        self.assertEqual(properties['python_version_major_minor'], 1.2)
-        self.assertEqual(properties['python_patchlevel'], 3)
-        self.assertEqual(properties['kernel_version'], 'Bazinga')
+        self.assertEqual(properties["distro"], "Smarty")
+        self.assertEqual(properties["distro_version"], 2.2)
+        self.assertEqual(properties["python_version_major_minor"], 1.2)
+        self.assertEqual(properties["python_patchlevel"], 3)
+        self.assertEqual(properties["kernel_version"], "Bazinga")

--- a/tests/audit/test_client_audit.py
+++ b/tests/audit/test_client_audit.py
@@ -14,11 +14,14 @@ class TestClientAudit(PatchedContextTestCase):
             "target": "/mnt/lustre_clients/testfs",
             "source": "10.0.0.129@tcp:/testfs",
             "fstype": "lustre",
-            "opts": "rw"}
+            "opts": "rw",
+        }
 
-        device_map = {'blockDevices': {}, 'zed': {}, 'localMounts': [client_mount]}
-        mock.patch('chroma_agent.device_plugins.block_devices.scanner_cmd',
-                   return_value=device_map).start()
+        device_map = {"blockDevices": {}, "zed": {}, "localMounts": [client_mount]}
+        mock.patch(
+            "chroma_agent.device_plugins.block_devices.scanner_cmd",
+            return_value=device_map,
+        ).start()
 
         self.audit = ClientAudit()
 
@@ -26,7 +29,11 @@ class TestClientAudit(PatchedContextTestCase):
         assert ClientAudit.is_available()
 
     def test_gathered_mount_list(self):
-        actual_list = self.audit.metrics()['raw']['lustre_client_mounts']
-        expected_list = [dict(mountspec='10.0.0.129@tcp:/testfs',
-                              mountpoint='/mnt/lustre_clients/testfs')]
+        actual_list = self.audit.metrics()["raw"]["lustre_client_mounts"]
+        expected_list = [
+            dict(
+                mountspec="10.0.0.129@tcp:/testfs",
+                mountpoint="/mnt/lustre_clients/testfs",
+            )
+        ]
         self.assertEqual(actual_list, expected_list)

--- a/tests/audit/test_lnet_audit.py
+++ b/tests/audit/test_lnet_audit.py
@@ -6,8 +6,10 @@ from tests.test_utils import PatchedContextTestCase
 
 class TestLnetAudit(PatchedContextTestCase):
     def setUp(self):
-        tests = os.path.join(os.path.dirname(__file__), '..')
-        self.test_root = os.path.join(tests, "data/lustre_versions/2.9.58_86_g2383a62/mds_mgs")
+        tests = os.path.join(os.path.dirname(__file__), "..")
+        self.test_root = os.path.join(
+            tests, "data/lustre_versions/2.9.58_86_g2383a62/mds_mgs"
+        )
         super(TestLnetAudit, self).setUp()
         self.audit = LnetAudit()
 

--- a/tests/audit/test_lustre.py
+++ b/tests/audit/test_lustre.py
@@ -2,15 +2,22 @@ import tempfile
 import os
 import shutil
 import chroma_agent.device_plugins.audit.lustre
-from chroma_agent.device_plugins.audit.lustre import LnetAudit, MdtAudit, MgsAudit, LustreAudit
+from chroma_agent.device_plugins.audit.lustre import (
+    LnetAudit,
+    MdtAudit,
+    MgsAudit,
+    LustreAudit,
+)
 
 from tests.test_utils import PatchedContextTestCase
 
 
 class TestLustreAuditClassMethods(PatchedContextTestCase):
     def setUp(self):
-        tests = os.path.join(os.path.dirname(__file__), '..')
-        self.test_root = os.path.join(tests, "data/lustre_versions/2.9.58_86_g2383a62/mds_mgs")
+        tests = os.path.join(os.path.dirname(__file__), "..")
+        self.test_root = os.path.join(
+            tests, "data/lustre_versions/2.9.58_86_g2383a62/mds_mgs"
+        )
         super(TestLustreAuditClassMethods, self).setUp()
 
     def test_kmod_is_loaded(self):
@@ -28,18 +35,24 @@ class TestLustreAuditClassMethods(PatchedContextTestCase):
 
 class TestLustreAuditScanner(PatchedContextTestCase):
     def test_2x_audit_scanner(self):
-        tests = os.path.join(os.path.dirname(__file__), '..')
-        self.test_root = os.path.join(tests, "data/lustre_versions/2.9.58_86_g2383a62/mds_mgs")
+        tests = os.path.join(os.path.dirname(__file__), "..")
+        self.test_root = os.path.join(
+            tests, "data/lustre_versions/2.9.58_86_g2383a62/mds_mgs"
+        )
         super(TestLustreAuditScanner, self).setUp()
-        list = [cls.__name__ for cls in
-                chroma_agent.device_plugins.audit.lustre.local_audit_classes()]
-        self.assertEqual(list, ['LnetAudit', 'MdtAudit', 'MgsAudit'])
+        list = [
+            cls.__name__
+            for cls in chroma_agent.device_plugins.audit.lustre.local_audit_classes()
+        ]
+        self.assertEqual(list, ["LnetAudit", "MdtAudit", "MgsAudit"])
 
 
 class TestLustreAudit(PatchedContextTestCase):
     def setUp(self):
-        tests = os.path.join(os.path.dirname(__file__), '..')
-        self.test_root = os.path.join(tests, "data/lustre_versions/2.9.58_86_g2383a62/mds_mgs")
+        tests = os.path.join(os.path.dirname(__file__), "..")
+        self.test_root = os.path.join(
+            tests, "data/lustre_versions/2.9.58_86_g2383a62/mds_mgs"
+        )
         super(TestLustreAudit, self).setUp()
         self.audit = LustreAudit()
 
@@ -47,14 +60,15 @@ class TestLustreAudit(PatchedContextTestCase):
         self.assertEqual(self.audit.version, "2.9.58_86_g2383a62")
 
     def test_version_info(self):
-        self.assertEqual(self.audit.version_info,
-                         self.audit.LustreVersion(2, 9, 58))
+        self.assertEqual(self.audit.version_info, self.audit.LustreVersion(2, 9, 58))
 
 
 class TestGitLustreVersion(PatchedContextTestCase):
     def setUp(self):
-        tests = os.path.join(os.path.dirname(__file__), '..')
-        self.test_root = os.path.join(tests, "data/lustre_versions/2.9.58_86_g2383a62/mds_mgs")
+        tests = os.path.join(os.path.dirname(__file__), "..")
+        self.test_root = os.path.join(
+            tests, "data/lustre_versions/2.9.58_86_g2383a62/mds_mgs"
+        )
         super(TestGitLustreVersion, self).setUp()
         self.audit = LustreAudit()
 
@@ -62,13 +76,12 @@ class TestGitLustreVersion(PatchedContextTestCase):
         self.assertEqual(self.audit.version, "2.9.58_86_g2383a62")
 
     def test_version_info(self):
-        self.assertEqual(self.audit.version_info,
-                         self.audit.LustreVersion(2, 9, 58))
+        self.assertEqual(self.audit.version_info, self.audit.LustreVersion(2, 9, 58))
 
 
 class TestMisformedLustreVersion(PatchedContextTestCase):
     def setUp(self):
-        tests = os.path.join(os.path.dirname(__file__), '..')
+        tests = os.path.join(os.path.dirname(__file__), "..")
         self.test_root = os.path.join(tests, "data/lustre_versions/2.bad/mds_mgs")
         super(TestMisformedLustreVersion, self).setUp()
         self.audit = LustreAudit()
@@ -82,6 +95,7 @@ class TestMisformedLustreVersion(PatchedContextTestCase):
 
 class TestMissingLustreVersion(PatchedContextTestCase):
     """No idea how this might happen, but it shouldn't crash the audit."""
+
     def setUp(self):
         self.test_root = tempfile.mkdtemp()
         super(TestMissingLustreVersion, self).setUp()

--- a/tests/audit/test_mds_audit.py
+++ b/tests/audit/test_mds_audit.py
@@ -5,11 +5,11 @@ from tests.test_utils import PatchedContextTestCase
 
 
 class TestMdsAudit(PatchedContextTestCase):
-
     def test_mdd_obd_skipped(self):
         """Test that the mdd_obd device is skipped for 2.x audits (HYD-437)"""
-        tests = os.path.join(os.path.dirname(__file__), '..')
+        tests = os.path.join(os.path.dirname(__file__), "..")
         self.test_root = os.path.join(
-            tests, "data/lustre_versions/2.9.58_86_g2383a62/mds_mgs")
+            tests, "data/lustre_versions/2.9.58_86_g2383a62/mds_mgs"
+        )
         super(TestMdsAudit, self).setUp()
         self.assertFalse(MdsAudit.is_available())

--- a/tests/audit/test_mdt_audit.py
+++ b/tests/audit/test_mdt_audit.py
@@ -6,8 +6,10 @@ from tests.test_utils import PatchedContextTestCase
 
 class TestMdtAudit(PatchedContextTestCase):
     def setUp(self):
-        tests = os.path.join(os.path.dirname(__file__), '..')
-        self.test_root = os.path.join(tests, "data/lustre_versions/2.9.58_86_g2383a62/mds_mgs")
+        tests = os.path.join(os.path.dirname(__file__), "..")
+        self.test_root = os.path.join(
+            tests, "data/lustre_versions/2.9.58_86_g2383a62/mds_mgs"
+        )
         super(TestMdtAudit, self).setUp()
         self.audit = MdtAudit()
 

--- a/tests/audit/test_obdfilter_audit.py
+++ b/tests/audit/test_obdfilter_audit.py
@@ -7,7 +7,7 @@ from tests.test_utils import PatchedContextTestCase
 
 class TestObdfilterAudit(PatchedContextTestCase):
     def setUp(self):
-        tests = os.path.join(os.path.dirname(__file__), '..')
+        tests = os.path.join(os.path.dirname(__file__), "..")
         # 2.9.58_jobstats modules file has entries for obdfilter as well as ost, which is not necessarily the case,
         # 2.9.58_86_g2383a62 modules file has ost but no obdfilter entries. Both are valid scenarios.
         self.test_root = os.path.join(tests, "data/lustre_versions/2.9.58_jobstats/oss")
@@ -36,103 +36,158 @@ class TestObdfilterAuditReadingJobStats(unittest.TestCase):
 
         #  simulate job stats turned off
         self.audit._read_job_stats_yaml_file = lambda target_name: None
-        res = self.audit.read_job_stats('OST0000')
+        res = self.audit.read_job_stats("OST0000")
 
         self.assertEqual(res, [], res)
-        self.assertEqual(self.audit.job_stat_last_snapshot_time, {}, self.audit.job_stat_last_snapshot_time)
+        self.assertEqual(
+            self.audit.job_stat_last_snapshot_time,
+            {},
+            self.audit.job_stat_last_snapshot_time,
+        )
 
         #  simulate job stats turned on, but has nothing to report, same return as off
         self.audit._read_job_stats_yaml_file = lambda target_name: []
-        res = self.audit.read_job_stats('OST0000')
+        res = self.audit.read_job_stats("OST0000")
         self.assertEqual(res, [], res)
-        self.assertEqual(self.audit.job_stat_last_snapshot_time, {}, self.audit.job_stat_last_snapshot_time)
+        self.assertEqual(
+            self.audit.job_stat_last_snapshot_time,
+            {},
+            self.audit.job_stat_last_snapshot_time,
+        )
 
         #  This sample stats file output for next 2 tests
-        self.audit._read_job_stats_yaml_file = lambda target_name: [{'job_id': 16,
-                                                        'snapshot_time': 1416616379,
-                                                        'read_bytes': {'samples': 0,
-                                                                   'unit': 'bytes',
-                                                                    'min': 0,
-                                                                    'max': 0,
-                                                                    'sum': 0},
-                                                         'write_bytes': {'samples': 1,
-                                                                     'unit': 'bytes',
-                                                                     'min': 102400,
-                                                                     'max': 102400,
-                                                                     'sum': 102400}
-                                                        }]
+        self.audit._read_job_stats_yaml_file = lambda target_name: [
+            {
+                "job_id": 16,
+                "snapshot_time": 1416616379,
+                "read_bytes": {
+                    "samples": 0,
+                    "unit": "bytes",
+                    "min": 0,
+                    "max": 0,
+                    "sum": 0,
+                },
+                "write_bytes": {
+                    "samples": 1,
+                    "unit": "bytes",
+                    "min": 102400,
+                    "max": 102400,
+                    "sum": 102400,
+                },
+            }
+        ]
 
         #  Test that the reading adds the record to the snapshot dict, and returns it
-        res = self.audit.read_job_stats('OST0000')
-        self.assertEqual(self.audit.job_stat_last_snapshot_time, {16: 1416616379}, self.audit.job_stat_last_snapshot_time)
+        res = self.audit.read_job_stats("OST0000")
+        self.assertEqual(
+            self.audit.job_stat_last_snapshot_time,
+            {16: 1416616379},
+            self.audit.job_stat_last_snapshot_time,
+        )
         self.assertEqual(len(res), 1, res)
 
         # Second read, no change in proc file, so no change in snapshot dict (same value), and returning nothing
-        res = self.audit.read_job_stats('OST0000')
+        res = self.audit.read_job_stats("OST0000")
         self.assertEqual(res, [], res)
-        self.assertEqual(self.audit.job_stat_last_snapshot_time, {16: 1416616379}, self.audit.job_stat_last_snapshot_time)
+        self.assertEqual(
+            self.audit.job_stat_last_snapshot_time,
+            {16: 1416616379},
+            self.audit.job_stat_last_snapshot_time,
+        )
 
         #  Simulate new job stats proc file was updated with new snapshot_time for job 16
-        self.audit._read_job_stats_yaml_file = lambda target_name: [{'job_id': 16,
-                                                         'snapshot_time': 1416616599,
-                                                         'read_bytes': {'samples': 0,
-                                                                   'unit': 'bytes',
-                                                                   'min': 0,
-                                                                   'max': 0,
-                                                                   'sum': 0},
-                                                         'write_bytes': {'samples': 1,
-                                                                    'unit': 'bytes',
-                                                                    'min': 102400,
-                                                                    'max': 102400,
-                                                                    'sum': 102400}
-                                                        }]
+        self.audit._read_job_stats_yaml_file = lambda target_name: [
+            {
+                "job_id": 16,
+                "snapshot_time": 1416616599,
+                "read_bytes": {
+                    "samples": 0,
+                    "unit": "bytes",
+                    "min": 0,
+                    "max": 0,
+                    "sum": 0,
+                },
+                "write_bytes": {
+                    "samples": 1,
+                    "unit": "bytes",
+                    "min": 102400,
+                    "max": 102400,
+                    "sum": 102400,
+                },
+            }
+        ]
 
         #  Test that only one record is in the cache, the latest record, and that this new record is returned
-        res = self.audit.read_job_stats('OST0000')
-        self.assertTrue({16: 1416616379} not in self.audit.job_stat_last_snapshot_time.items(), self.audit.job_stat_last_snapshot_time)
-        self.assertEqual(self.audit.job_stat_last_snapshot_time, {16: 1416616599}, self.audit.job_stat_last_snapshot_time)
+        res = self.audit.read_job_stats("OST0000")
+        self.assertTrue(
+            {16: 1416616379} not in self.audit.job_stat_last_snapshot_time.items(),
+            self.audit.job_stat_last_snapshot_time,
+        )
+        self.assertEqual(
+            self.audit.job_stat_last_snapshot_time,
+            {16: 1416616599},
+            self.audit.job_stat_last_snapshot_time,
+        )
         self.assertEqual(len(res), 1, res)
-        self.assertEqual(res[0]['snapshot_time'], 1416616599, res)
+        self.assertEqual(res[0]["snapshot_time"], 1416616599, res)
 
     def test_snapshot_time_autoclear(self):
         """Test that the cache holds only active jobs after a clear"""
 
-        self.audit._read_job_stats_yaml_file = lambda target_name: [{'job_id': 16,
-                                                         'snapshot_time': 1416616379,
-                                                         'read_bytes': {'samples': 0,
-                                                                   'unit': 'bytes',
-                                                                   'min': 0,
-                                                                   'max': 0,
-                                                                   'sum': 0},
-                                                         'write_bytes': {'samples': 1,
-                                                                    'unit': 'bytes',
-                                                                    'min': 102400,
-                                                                    'max': 102400,
-                                                                    'sum': 102400}
-                                                        }]
+        self.audit._read_job_stats_yaml_file = lambda target_name: [
+            {
+                "job_id": 16,
+                "snapshot_time": 1416616379,
+                "read_bytes": {
+                    "samples": 0,
+                    "unit": "bytes",
+                    "min": 0,
+                    "max": 0,
+                    "sum": 0,
+                },
+                "write_bytes": {
+                    "samples": 1,
+                    "unit": "bytes",
+                    "min": 102400,
+                    "max": 102400,
+                    "sum": 102400,
+                },
+            }
+        ]
 
         #  Add this stat to the cache
-        res = self.audit.read_job_stats('OST0000')
+        res = self.audit.read_job_stats("OST0000")
 
         #  Next stat shows a new job_id, and DOES NOT SHOW the old id 16.  This means 16 is no longer reporting
         #  This situation can happen in Lustre does an autoclear between these to samples, and 16 has nothing to report.
-        self.audit._read_job_stats_yaml_file = lambda target_name: [{'job_id': 17,
-                                                         'snapshot_time': 1416616399,
-                                                         'read_bytes': {'samples': 0,
-                                                                   'unit': 'bytes',
-                                                                   'min': 0,
-                                                                   'max': 0,
-                                                                   'sum': 0},
-                                                         'write_bytes': {'samples': 1,
-                                                                    'unit': 'bytes',
-                                                                    'min': 102400,
-                                                                    'max': 102400,
-                                                                    'sum': 102400}
-                                                        }]
+        self.audit._read_job_stats_yaml_file = lambda target_name: [
+            {
+                "job_id": 17,
+                "snapshot_time": 1416616399,
+                "read_bytes": {
+                    "samples": 0,
+                    "unit": "bytes",
+                    "min": 0,
+                    "max": 0,
+                    "sum": 0,
+                },
+                "write_bytes": {
+                    "samples": 1,
+                    "unit": "bytes",
+                    "min": 102400,
+                    "max": 102400,
+                    "sum": 102400,
+                },
+            }
+        ]
 
         #  Test that the cache only have the job_id 17, and not 16 anymore, and that the return is only for 17.
-        res = self.audit.read_job_stats('OST0000')
-        self.assertEqual(self.audit.job_stat_last_snapshot_time, {17: 1416616399}, self.audit.job_stat_last_snapshot_time)
+        res = self.audit.read_job_stats("OST0000")
+        self.assertEqual(
+            self.audit.job_stat_last_snapshot_time,
+            {17: 1416616399},
+            self.audit.job_stat_last_snapshot_time,
+        )
         self.assertEqual(len(res), 1, res)
-        self.assertFalse(16 in (r['job_id'] for r in res), res)
-        self.assertTrue(17 in (r['job_id'] for r in res), res)
+        self.assertFalse(16 in (r["job_id"] for r in res), res)
+        self.assertTrue(17 in (r["job_id"] for r in res), res)

--- a/tests/device_plugins/test_action_runner.py
+++ b/tests/device_plugins/test_action_runner.py
@@ -6,18 +6,25 @@ import mock
 from django.utils import unittest
 
 from chroma_agent.lib.shell import AgentShell
-from chroma_agent.device_plugins.action_runner import ActionRunnerPlugin, CallbackAfterResponse
+from chroma_agent.device_plugins.action_runner import (
+    ActionRunnerPlugin,
+    CallbackAfterResponse,
+)
 from chroma_agent.plugin_manager import ActionPluginManager, DevicePlugin
 from chroma_agent.agent_client import AgentDaemonContext
 
-ACTION_ONE_NO_CONTEXT_RETVAL = 'action_one_no_context_return'
-ACTION_ONE_WITH_CONTEXT_RETVAL = 'action_one_with_context_return'
-ACTION_TWO_RETVAL = 'action_two_return'
+ACTION_ONE_NO_CONTEXT_RETVAL = "action_one_no_context_return"
+ACTION_ONE_WITH_CONTEXT_RETVAL = "action_one_with_context_return"
+ACTION_TWO_RETVAL = "action_two_return"
 
 
 subprocesses = {
-    ('subprocess_one', 'subprocess_one_arg'): lambda: AgentShell.RunResult(0, 'subprocess_one_stdout', 'subprocess_one_stderr', False),
-    ('subprocess_two', 'subprocess_two_arg'): lambda: AgentShell.RunResult(-1, 'subprocess_two_stdout', 'subprocess_two_stderr', False)
+    ("subprocess_one", "subprocess_one_arg"): lambda: AgentShell.RunResult(
+        0, "subprocess_one_stdout", "subprocess_one_stderr", False
+    ),
+    ("subprocess_two", "subprocess_two_arg"): lambda: AgentShell.RunResult(
+        -1, "subprocess_two_stdout", "subprocess_two_stderr", False
+    ),
 }
 
 
@@ -25,8 +32,8 @@ def action_one_no_context(arg1):
     """An action which invokes subprocess_one"""
 
     assert arg1 == "arg1_test"
-    stdout = AgentShell.try_run(['subprocess_one', 'subprocess_one_arg'])
-    assert stdout == 'subprocess_one_stdout'
+    stdout = AgentShell.try_run(["subprocess_one", "subprocess_one_arg"])
+    assert stdout == "subprocess_one_stdout"
     return ACTION_ONE_NO_CONTEXT_RETVAL
 
 
@@ -35,8 +42,8 @@ def action_one_with_context(agent_daemon_context, arg1):
 
     assert isinstance(agent_daemon_context, AgentDaemonContext)
     assert arg1 == "arg1_test"
-    stdout = AgentShell.try_run(['subprocess_one', 'subprocess_one_arg'])
-    assert stdout == 'subprocess_one_stdout'
+    stdout = AgentShell.try_run(["subprocess_one", "subprocess_one_arg"])
+    assert stdout == "subprocess_one_stdout"
     return ACTION_ONE_WITH_CONTEXT_RETVAL
 
 
@@ -44,16 +51,16 @@ def action_two(arg1):
     """An action which invokes subprocess_one and subprocess_two"""
 
     assert arg1 == "arg2_test"
-    stdout = AgentShell.try_run(['subprocess_one', 'subprocess_one_arg'])
-    assert stdout == 'subprocess_one_stdout'
-    AgentShell.try_run(['subprocess_two', 'subprocess_two_arg'])
+    stdout = AgentShell.try_run(["subprocess_one", "subprocess_one_arg"])
+    assert stdout == "subprocess_one_stdout"
+    AgentShell.try_run(["subprocess_two", "subprocess_two_arg"])
     return ACTION_TWO_RETVAL
 
 
 def action_three():
     """An action which runs for a long time unless interrupted"""
 
-    AgentShell.try_run(['sleep', '10000'])
+    AgentShell.try_run(["sleep", "10000"])
     raise AssertionError("subprocess three should last forever!")
 
 
@@ -61,21 +68,30 @@ def action_four():
     """An action which raises an CallbackAfterResponse"""
 
     def action_four_callback():
-        return 'action_four_called_back'
+        return "action_four_called_back"
 
-    raise CallbackAfterResponse('result', action_four_callback)
+    raise CallbackAfterResponse("result", action_four_callback)
 
-ACTIONS = [action_one_no_context, action_one_with_context, action_two, action_three, action_four]
+
+ACTIONS = [
+    action_one_no_context,
+    action_one_with_context,
+    action_two,
+    action_three,
+    action_four,
+]
 
 
 class ActionTestCase(unittest.TestCase):
     MOCK_SUBPROCESSES = None
 
-    SendMessageParams = namedtuple('SendMessageParams', ['body', 'callback'])
+    SendMessageParams = namedtuple("SendMessageParams", ["body", "callback"])
 
-    def mock_send_message(self, body, callback = None):
+    def mock_send_message(self, body, callback=None):
         self.mock_send_message_lock.acquire()
-        self.mock_send_message_call_args_list.append(self.SendMessageParams(body, callback))
+        self.mock_send_message_call_args_list.append(
+            self.SendMessageParams(body, callback)
+        )
         self.mock_send_message_call_count += 1
         self.mock_send_message_lock.release()
 
@@ -89,14 +105,17 @@ class ActionTestCase(unittest.TestCase):
             self.action_plugins.commands[action.__name__] = action
 
         # Intercept messages sent with a thread safe mock
-        mock.patch('chroma_agent.plugin_manager.DevicePlugin.send_message', self.mock_send_message).start()
+        mock.patch(
+            "chroma_agent.plugin_manager.DevicePlugin.send_message",
+            self.mock_send_message,
+        ).start()
         self.mock_send_message_lock = threading.Lock()
         self.mock_send_message_call_count = 0
         self.mock_send_message_call_args_list = []
 
         # Intercept subprocess invocations
         if self.MOCK_SUBPROCESSES:
-            mock.patch('iml_common.lib.shell.BaseShell._run', self.mock_run).start()
+            mock.patch("iml_common.lib.shell.BaseShell._run", self.mock_run).start()
 
         # Guaranteed cleanup with unittest2
         self.addCleanup(mock.patch.stopall)
@@ -111,6 +130,7 @@ class TestActionPluginManager(ActionTestCase):
     Test running actions directly as a precursor to testing running them
     via ActionRunner.
     """
+
     MOCK_SUBPROCESSES = subprocesses
 
     def test_run_direct_success(self):
@@ -118,9 +138,9 @@ class TestActionPluginManager(ActionTestCase):
         Test that we can run an action directly using ActionPluginManager as the
         CLI would.
         """
-        result = ActionPluginManager().run('action_one_no_context',
-                                           None,
-                                           {'arg1': "arg1_test"})
+        result = ActionPluginManager().run(
+            "action_one_no_context", None, {"arg1": "arg1_test"}
+        )
         self.assertEqual(result, ACTION_ONE_NO_CONTEXT_RETVAL)
 
     def test_run_direct_failure(self):
@@ -128,18 +148,18 @@ class TestActionPluginManager(ActionTestCase):
         Test that ActionPluginManager.run re-raises exceptions
         """
         with self.assertRaises(AssertionError):
-            ActionPluginManager().run('action_one_no_context',
-                                      None,
-                                      {'arg1': "the_wrong_thing"})
+            ActionPluginManager().run(
+                "action_one_no_context", None, {"arg1": "the_wrong_thing"}
+            )
 
     def test_run_direct_success_with_context(self):
         """
         Test that we can run an action using ActionPluginManager as the
         daemon would.
         """
-        result = ActionPluginManager().run('action_one_with_context',
-                                           AgentDaemonContext([]),
-                                           {'arg1': "arg1_test"})
+        result = ActionPluginManager().run(
+            "action_one_with_context", AgentDaemonContext([]), {"arg1": "arg1_test"}
+        )
         self.assertEqual(result, ACTION_ONE_WITH_CONTEXT_RETVAL)
 
 
@@ -165,12 +185,9 @@ class ActionRunnerPluginTestCase(ActionTestCase):
         """
         id = "%s" % self._id_counter
         self._id_counter += 1
-        self.action_runner.on_message({
-            'type': 'ACTION_START',
-            'id': id,
-            'action': action,
-            'args': args
-        })
+        self.action_runner.on_message(
+            {"type": "ACTION_START", "id": id, "action": action, "args": args}
+        )
         return id
 
     def _get_responses(self, count):
@@ -182,7 +199,10 @@ class ActionRunnerPluginTestCase(ActionTestCase):
             i += 1
 
             if i > TIMEOUT:
-                raise AssertionError("Timed out after %ss waiting for %s responses (got %s)" % (TIMEOUT, count, DevicePlugin.send_message.call_count))
+                raise AssertionError(
+                    "Timed out after %ss waiting for %s responses (got %s)"
+                    % (TIMEOUT, count, DevicePlugin.send_message.call_count)
+                )
 
         self.assertEqual(self.mock_send_message_call_count, count)
         return [args.body for args in self.mock_send_message_call_args_list]
@@ -198,45 +218,53 @@ class TestActionRunnerPlugin(ActionRunnerPluginTestCase):
         the manager would via the HTTPS agent comms)
         """
 
-        id = self._run_action('action_one_no_context', {'arg1': 'arg1_test'})
+        id = self._run_action("action_one_no_context", {"arg1": "arg1_test"})
         response = self._get_responses(1)[0]
-        self.assertDictEqual(response, {
-            'type': 'ACTION_COMPLETE',
-            'id': id,
-            'result': ACTION_ONE_NO_CONTEXT_RETVAL,
-            'exception': None,
-            'subprocesses': [{
-                'args': ['subprocess_one', 'subprocess_one_arg'],
-                'stdout': 'subprocess_one_stdout',
-                'stderr': 'subprocess_one_stderr',
-                'rc': 0
-            }]
-        })
+        self.assertDictEqual(
+            response,
+            {
+                "type": "ACTION_COMPLETE",
+                "id": id,
+                "result": ACTION_ONE_NO_CONTEXT_RETVAL,
+                "exception": None,
+                "subprocesses": [
+                    {
+                        "args": ["subprocess_one", "subprocess_one_arg"],
+                        "stdout": "subprocess_one_stdout",
+                        "stderr": "subprocess_one_stderr",
+                        "rc": 0,
+                    }
+                ],
+            },
+        )
 
     def test_run_action_runner_error(self):
         """
         Test running an action which experiences an error in a subprocess
         """
 
-        id = self._run_action('action_two', {'arg1': 'arg2_test'})
+        id = self._run_action("action_two", {"arg1": "arg2_test"})
         response = self._get_responses(1)[0]
-        self.assertEqual(response['id'], id)
-        self.assertIsNone(response['result'])
-        self.assertIsNotNone(response['exception'])
-        self.assertListEqual(response['subprocesses'], [
-            {
-                'args': ['subprocess_one', 'subprocess_one_arg'],
-                'stdout': 'subprocess_one_stdout',
-                'stderr': 'subprocess_one_stderr',
-                'rc': 0
-            },
-            {
-                'args': ['subprocess_two', 'subprocess_two_arg'],
-                'stdout': 'subprocess_two_stdout',
-                'stderr': 'subprocess_two_stderr',
-                'rc': -1
-            },
-            ])
+        self.assertEqual(response["id"], id)
+        self.assertIsNone(response["result"])
+        self.assertIsNotNone(response["exception"])
+        self.assertListEqual(
+            response["subprocesses"],
+            [
+                {
+                    "args": ["subprocess_one", "subprocess_one_arg"],
+                    "stdout": "subprocess_one_stdout",
+                    "stderr": "subprocess_one_stderr",
+                    "rc": 0,
+                },
+                {
+                    "args": ["subprocess_two", "subprocess_two_arg"],
+                    "stdout": "subprocess_two_stdout",
+                    "stderr": "subprocess_two_stderr",
+                    "rc": -1,
+                },
+            ],
+        )
 
     def test_1000_actions(self):
         """
@@ -247,45 +275,55 @@ class TestActionRunnerPlugin(ActionRunnerPluginTestCase):
 
         for action in xrange(0, actions):
             if action & 1:
-                ids[action] = self._run_action('action_one_no_context', {'arg1': 'arg1_test'})
+                ids[action] = self._run_action(
+                    "action_one_no_context", {"arg1": "arg1_test"}
+                )
             else:
-                ids[action] = self._run_action('action_two', {'arg1': 'arg2_test'})
+                ids[action] = self._run_action("action_two", {"arg1": "arg2_test"})
 
         responses = self._get_responses(actions)
 
         for action in xrange(0, actions):
-            response = next(r for r in responses if r['id'] == ids[action])
+            response = next(r for r in responses if r["id"] == ids[action])
 
             if action & 1:
-                self.assertDictEqual(response, {
-                    'type': 'ACTION_COMPLETE',
-                    'id': ids[action],
-                    'result': ACTION_ONE_NO_CONTEXT_RETVAL,
-                    'exception': None,
-                    'subprocesses': [{
-                                     'args': ['subprocess_one', 'subprocess_one_arg'],
-                                     'stdout': 'subprocess_one_stdout',
-                                     'stderr': 'subprocess_one_stderr',
-                                     'rc': 0
-                                 }]
-                })
+                self.assertDictEqual(
+                    response,
+                    {
+                        "type": "ACTION_COMPLETE",
+                        "id": ids[action],
+                        "result": ACTION_ONE_NO_CONTEXT_RETVAL,
+                        "exception": None,
+                        "subprocesses": [
+                            {
+                                "args": ["subprocess_one", "subprocess_one_arg"],
+                                "stdout": "subprocess_one_stdout",
+                                "stderr": "subprocess_one_stderr",
+                                "rc": 0,
+                            }
+                        ],
+                    },
+                )
             else:
-                self.assertIsNone(response['result'])
-                self.assertIsNotNone(response['exception'])
-                self.assertListEqual(response['subprocesses'], [
-                    {
-                        'args': ['subprocess_one', 'subprocess_one_arg'],
-                        'stdout': 'subprocess_one_stdout',
-                        'stderr': 'subprocess_one_stderr',
-                        'rc': 0
-                    },
-                    {
-                        'args': ['subprocess_two', 'subprocess_two_arg'],
-                        'stdout': 'subprocess_two_stdout',
-                        'stderr': 'subprocess_two_stderr',
-                        'rc': -1
-                    },
-                    ])
+                self.assertIsNone(response["result"])
+                self.assertIsNotNone(response["exception"])
+                self.assertListEqual(
+                    response["subprocesses"],
+                    [
+                        {
+                            "args": ["subprocess_one", "subprocess_one_arg"],
+                            "stdout": "subprocess_one_stdout",
+                            "stderr": "subprocess_one_stderr",
+                            "rc": 0,
+                        },
+                        {
+                            "args": ["subprocess_two", "subprocess_two_arg"],
+                            "stdout": "subprocess_two_stdout",
+                            "stderr": "subprocess_two_stderr",
+                            "rc": -1,
+                        },
+                    ],
+                )
 
 
 class TestActionRunnerPluginCancellation(ActionRunnerPluginTestCase):
@@ -296,7 +334,7 @@ class TestActionRunnerPluginCancellation(ActionRunnerPluginTestCase):
         # The action for this test has to be a bit subtle: we can't just override _run
         # because we need its behaviour
 
-        self._run_action('action_three', {})
+        self._run_action("action_three", {})
         # Now that something is in flight, try tearing down
         self.action_runner.teardown()
         # The main test here is that we actually return rather than blocking indefinitely
@@ -308,17 +346,14 @@ class TestActionRunnerPluginCancellation(ActionRunnerPluginTestCase):
         """Test that sending a cancellation message for a running action interrupts
         execution of subprocesses.  This is what happens on a particular action
         being cancelled from the manager"""
-        id = self._run_action('action_three', {})
+        id = self._run_action("action_three", {})
 
         # Grab the internal thread so that we can check it completes
         thread = self.action_runner._running_actions[id]
 
-        self.action_runner.on_message({
-            'type': 'ACTION_CANCEL',
-            'id': id,
-            'action': None,
-            'args': None
-        })
+        self.action_runner.on_message(
+            {"type": "ACTION_CANCEL", "id": id, "action": None, "args": None}
+        )
 
         # The thread should have stopped running
         thread.join(2.0)
@@ -342,7 +377,10 @@ class TestCallbackAfterResponse(ActionRunnerPluginTestCase):
             i += 1
 
             if i > TIMEOUT:
-                raise AssertionError("Timed out after %ss waiting for responses (got %s)" % (TIMEOUT, DevicePlugin.send_message.call_count))
+                raise AssertionError(
+                    "Timed out after %ss waiting for responses (got %s)"
+                    % (TIMEOUT, DevicePlugin.send_message.call_count)
+                )
 
         self.assertEqual(self.mock_send_message_call_count, 1)
         return self.mock_send_message_call_args_list[0]
@@ -352,7 +390,7 @@ class TestCallbackAfterResponse(ActionRunnerPluginTestCase):
         ActionRunnerPlugin tags the callback onto the Message that it sends
         onwards"""
 
-        self._run_action('action_four', {})
+        self._run_action("action_four", {})
 
         response_and_callback = self._get_response_and_callback()
-        self.assertEqual(response_and_callback.callback(), 'action_four_called_back')
+        self.assertEqual(response_and_callback.callback(), "action_four_called_back")

--- a/tests/device_plugins/test_block_devices.py
+++ b/tests/device_plugins/test_block_devices.py
@@ -4,7 +4,10 @@ import os
 from django.utils import unittest
 from mock import patch
 
-from chroma_agent.device_plugins.block_devices import get_normalized_device_table, get_local_mounts
+from chroma_agent.device_plugins.block_devices import (
+    get_normalized_device_table,
+    get_local_mounts,
+)
 
 
 # from chroma_core.services.plugin_runner import ResourceManager
@@ -160,12 +163,15 @@ from chroma_agent.device_plugins.block_devices import get_normalized_device_tabl
 #        self._start_session_with_data(host1, "NoDevices.json")
 #        self.assertEqual(Volume.objects.count(), 0)
 
+
 class TestBase(unittest.TestCase):
-    test_host_fqdn = 'vm5.foo.com'
+    test_host_fqdn = "vm5.foo.com"
 
     def setUp(self):
         super(TestBase, self).setUp()
-        self.test_root = os.path.join(os.path.dirname(__file__), "..", "data", "device_plugins")
+        self.test_root = os.path.join(
+            os.path.dirname(__file__), "..", "data", "device_plugins"
+        )
         self.addCleanup(patch.stopall)
 
     def load(self, filename):
@@ -181,16 +187,17 @@ class TestBase(unittest.TestCase):
             if type(expected) is dict:
                 self.check(skip_keys, expect[x], result[x], key)
             else:
-                self.assertEqual(actual, expected,
-                                 "item {} ({}) in {} does not match expected ({})".format(key,
-                                                                                          actual,
-                                                                                          x,
-                                                                                          expected))
+                self.assertEqual(
+                    actual,
+                    expected,
+                    "item {} ({}) in {} does not match expected ({})".format(
+                        key, actual, x, expected
+                    ),
+                )
 
-        pipe(expect[x].keys(),
-             cfilter(lambda y: y not in skip_keys),
-             cmap(cmpval),
-             list)
+        pipe(
+            expect[x].keys(), cfilter(lambda y: y not in skip_keys), cmap(cmpval), list
+        )
 
 
 class TestFormattedBlockDevices(TestBase):
@@ -199,73 +206,108 @@ class TestFormattedBlockDevices(TestBase):
     def setUp(self):
         super(TestFormattedBlockDevices, self).setUp()
 
-        self.fixture = json.loads(self.load(u'scanner-lu-mounted.out'))
+        self.fixture = json.loads(self.load(u"scanner-lu-mounted.out"))
         self.addCleanup(patch.stopall)
 
     def get_patched_ndt(self, fixture):
-        with patch('chroma_agent.device_plugins.block_devices.scanner_cmd', return_value=fixture):
+        with patch(
+            "chroma_agent.device_plugins.block_devices.scanner_cmd",
+            return_value=fixture,
+        ):
             return get_normalized_device_table()
 
     def get_patched_local_mounts(self, fixture):
-        with patch('chroma_agent.device_plugins.block_devices.scanner_cmd', return_value=fixture):
+        with patch(
+            "chroma_agent.device_plugins.block_devices.scanner_cmd",
+            return_value=fixture,
+        ):
             return get_local_mounts()
 
     def test_block_device_nodes_parsing(self):
         ndt = self.get_patched_ndt(self.fixture)
         self.assertDictEqual(
             ndt.table,
-            {u'/dev/disk/by-id/dm-name-vg_00-lv_swap': u'/dev/mapper/vg_00-lv_swap',
-             u'/dev/sda9': u'/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk15-part9',
-             u'/dev/sda1': u'/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk15-part1',
-             u'/dev/vda1': u'/dev/disk/by-id/virtio-mds1-root-part1',
-             u'/dev/disk/by-id/dm-name-vg_00-lv_root': u'/dev/mapper/vg_00-lv_root',
-             u'/dev/sde1': u'/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk11-part1',
-             u'/dev/sdc1': u'/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk13-part1',
-             u'/dev/sde9': u'/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk11-part9',
-             u'/dev/vda2': u'/dev/disk/by-id/virtio-mds1-root-part2',
-             u'/dev/sdc9': u'/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk13-part9',
-             u'/dev/disk/by-id/dm-uuid-LVM-Cc4ZWQKMN5QIi6g0u0JZPbz8AqpKDWAG8o6qNv1gVjlH3Vc5ffXsgxMyhD6pQell': u'/dev/mapper/vg_00-lv_swap',
-             u'/dev/sdb1': u'/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk14-part1',
-             u'/dev/disk/by-id/dm-uuid-LVM-Cc4ZWQKMN5QIi6g0u0JZPbz8AqpKDWAGNmyDCC1xFusBxh4wGcxbCynAYRnReWgi': u'/dev/mapper/vg_00-lv_root',
-             u'/dev/sdd9': u'/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk12-part9',
-             u'/dev/vda': u'/dev/disk/by-id/virtio-mds1-root',
-             u'/dev/sdb9': u'/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk14-part9',
-             u'/dev/sdd1': u'/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk12-part1',
-             u'/dev/dm-0': u'/dev/disk/by-id/dm-uuid-LVM-Cc4ZWQKMN5QIi6g0u0JZPbz8AqpKDWAGNmyDCC1xFusBxh4wGcxbCynAYRnReWgi',
-             u'/dev/dm-1': u'/dev/disk/by-id/dm-uuid-LVM-Cc4ZWQKMN5QIi6g0u0JZPbz8AqpKDWAG8o6qNv1gVjlH3Vc5ffXsgxMyhD6pQell',
-             u'/dev/sdd': u'/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk12',
-             u'/dev/sde': u'/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk11',
-             u'/dev/sdb': u'/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk14',
-             u'/dev/sdc': u'/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk13',
-             u'/dev/sda': u'/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk15'}
+            {
+                u"/dev/disk/by-id/dm-name-vg_00-lv_swap": u"/dev/mapper/vg_00-lv_swap",
+                u"/dev/sda9": u"/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk15-part9",
+                u"/dev/sda1": u"/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk15-part1",
+                u"/dev/vda1": u"/dev/disk/by-id/virtio-mds1-root-part1",
+                u"/dev/disk/by-id/dm-name-vg_00-lv_root": u"/dev/mapper/vg_00-lv_root",
+                u"/dev/sde1": u"/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk11-part1",
+                u"/dev/sdc1": u"/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk13-part1",
+                u"/dev/sde9": u"/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk11-part9",
+                u"/dev/vda2": u"/dev/disk/by-id/virtio-mds1-root-part2",
+                u"/dev/sdc9": u"/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk13-part9",
+                u"/dev/disk/by-id/dm-uuid-LVM-Cc4ZWQKMN5QIi6g0u0JZPbz8AqpKDWAG8o6qNv1gVjlH3Vc5ffXsgxMyhD6pQell": u"/dev/mapper/vg_00-lv_swap",
+                u"/dev/sdb1": u"/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk14-part1",
+                u"/dev/disk/by-id/dm-uuid-LVM-Cc4ZWQKMN5QIi6g0u0JZPbz8AqpKDWAGNmyDCC1xFusBxh4wGcxbCynAYRnReWgi": u"/dev/mapper/vg_00-lv_root",
+                u"/dev/sdd9": u"/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk12-part9",
+                u"/dev/vda": u"/dev/disk/by-id/virtio-mds1-root",
+                u"/dev/sdb9": u"/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk14-part9",
+                u"/dev/sdd1": u"/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk12-part1",
+                u"/dev/dm-0": u"/dev/disk/by-id/dm-uuid-LVM-Cc4ZWQKMN5QIi6g0u0JZPbz8AqpKDWAGNmyDCC1xFusBxh4wGcxbCynAYRnReWgi",
+                u"/dev/dm-1": u"/dev/disk/by-id/dm-uuid-LVM-Cc4ZWQKMN5QIi6g0u0JZPbz8AqpKDWAG8o6qNv1gVjlH3Vc5ffXsgxMyhD6pQell",
+                u"/dev/sdd": u"/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk12",
+                u"/dev/sde": u"/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk11",
+                u"/dev/sdb": u"/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk14",
+                u"/dev/sdc": u"/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk13",
+                u"/dev/sda": u"/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk15",
+            },
         )
 
     def test_local_mounts_parsing(self):
         mounts = self.get_patched_local_mounts(self.fixture)
         expected_mounts = [
-            (u'-hosts', u'/net', u'autofs'), (u'/dev/mapper/vg_00-lv_root', u'/', u'ext4'),
-            (u'/dev/mapper/vg_00-lv_swap', u'swap', u'swap'), (u'/dev/vda1', u'/boot', u'ext3'),
-            (u'/etc/auto.misc', u'/misc', u'autofs'), (u'auto.direct', u'/root/chef', u'autofs'),
-            (u'auto.direct', u'/root/lab', u'autofs'), (u'auto.direct', u'/scratch', u'autofs'),
-            (u'auto.home', u'/home', u'autofs'), (u'cgroup', u'/sys/fs/cgroup/blkio', u'cgroup'),
-            (u'cgroup', u'/sys/fs/cgroup/cpu,cpuacct', u'cgroup'), (u'cgroup', u'/sys/fs/cgroup/cpuset', u'cgroup'),
-            (u'cgroup', u'/sys/fs/cgroup/devices', u'cgroup'), (u'cgroup', u'/sys/fs/cgroup/freezer', u'cgroup'),
-            (u'cgroup', u'/sys/fs/cgroup/hugetlb', u'cgroup'), (u'cgroup', u'/sys/fs/cgroup/memory', u'cgroup'),
-            (u'cgroup', u'/sys/fs/cgroup/net_cls,net_prio', u'cgroup'),
-            (u'cgroup', u'/sys/fs/cgroup/perf_event', u'cgroup'), (u'cgroup', u'/sys/fs/cgroup/pids', u'cgroup'),
-            (u'cgroup', u'/sys/fs/cgroup/systemd', u'cgroup'), (u'configfs', u'/sys/kernel/config', u'configfs'),
-            (u'debugfs', u'/sys/kernel/debug', u'debugfs'), (u'devpts', u'/dev/pts', u'devpts'),
-            (u'devtmpfs', u'/dev', u'devtmpfs'), (u'hugetlbfs', u'/dev/hugepages', u'hugetlbfs'),
-            (u'mqueue', u'/dev/mqueue', u'mqueue'), (u'nfsd', u'/proc/fs/nfsd', u'nfsd'), (u'proc', u'/proc', u'proc'),
-            (u'pstore', u'/sys/fs/pstore', u'pstore'), (u'securityfs', u'/sys/kernel/security', u'securityfs'),
-            (u'sunrpc', u'/var/lib/nfs/rpc_pipefs', u'rpc_pipefs'), (u'sysfs', u'/sys', u'sysfs'),
-            (u'systemd-1', u'/proc/sys/fs/binfmt_misc', u'autofs'), (u'tmpfs', u'/dev/shm', u'tmpfs'),
-            (u'tmpfs', u'/run', u'tmpfs'), (u'tmpfs', u'/run/user/0', u'tmpfs'),
-            (u'tmpfs', u'/sys/fs/cgroup', u'tmpfs'),
-            (u'zfs_pool_scsi0QEMU_QEMU_HARDDISK_disk11', u'/zfs_pool_scsi0QEMU_QEMU_HARDDISK_disk11', u'zfs'),
-            (u'zfs_pool_scsi0QEMU_QEMU_HARDDISK_disk11/mgt_index0', u'/mnt/mdt', u'lustre')
+            (u"-hosts", u"/net", u"autofs"),
+            (u"/dev/mapper/vg_00-lv_root", u"/", u"ext4"),
+            (u"/dev/mapper/vg_00-lv_swap", u"swap", u"swap"),
+            (u"/dev/vda1", u"/boot", u"ext3"),
+            (u"/etc/auto.misc", u"/misc", u"autofs"),
+            (u"auto.direct", u"/root/chef", u"autofs"),
+            (u"auto.direct", u"/root/lab", u"autofs"),
+            (u"auto.direct", u"/scratch", u"autofs"),
+            (u"auto.home", u"/home", u"autofs"),
+            (u"cgroup", u"/sys/fs/cgroup/blkio", u"cgroup"),
+            (u"cgroup", u"/sys/fs/cgroup/cpu,cpuacct", u"cgroup"),
+            (u"cgroup", u"/sys/fs/cgroup/cpuset", u"cgroup"),
+            (u"cgroup", u"/sys/fs/cgroup/devices", u"cgroup"),
+            (u"cgroup", u"/sys/fs/cgroup/freezer", u"cgroup"),
+            (u"cgroup", u"/sys/fs/cgroup/hugetlb", u"cgroup"),
+            (u"cgroup", u"/sys/fs/cgroup/memory", u"cgroup"),
+            (u"cgroup", u"/sys/fs/cgroup/net_cls,net_prio", u"cgroup"),
+            (u"cgroup", u"/sys/fs/cgroup/perf_event", u"cgroup"),
+            (u"cgroup", u"/sys/fs/cgroup/pids", u"cgroup"),
+            (u"cgroup", u"/sys/fs/cgroup/systemd", u"cgroup"),
+            (u"configfs", u"/sys/kernel/config", u"configfs"),
+            (u"debugfs", u"/sys/kernel/debug", u"debugfs"),
+            (u"devpts", u"/dev/pts", u"devpts"),
+            (u"devtmpfs", u"/dev", u"devtmpfs"),
+            (u"hugetlbfs", u"/dev/hugepages", u"hugetlbfs"),
+            (u"mqueue", u"/dev/mqueue", u"mqueue"),
+            (u"nfsd", u"/proc/fs/nfsd", u"nfsd"),
+            (u"proc", u"/proc", u"proc"),
+            (u"pstore", u"/sys/fs/pstore", u"pstore"),
+            (u"securityfs", u"/sys/kernel/security", u"securityfs"),
+            (u"sunrpc", u"/var/lib/nfs/rpc_pipefs", u"rpc_pipefs"),
+            (u"sysfs", u"/sys", u"sysfs"),
+            (u"systemd-1", u"/proc/sys/fs/binfmt_misc", u"autofs"),
+            (u"tmpfs", u"/dev/shm", u"tmpfs"),
+            (u"tmpfs", u"/run", u"tmpfs"),
+            (u"tmpfs", u"/run/user/0", u"tmpfs"),
+            (u"tmpfs", u"/sys/fs/cgroup", u"tmpfs"),
+            (
+                u"zfs_pool_scsi0QEMU_QEMU_HARDDISK_disk11",
+                u"/zfs_pool_scsi0QEMU_QEMU_HARDDISK_disk11",
+                u"zfs",
+            ),
+            (
+                u"zfs_pool_scsi0QEMU_QEMU_HARDDISK_disk11/mgt_index0",
+                u"/mnt/mdt",
+                u"lustre",
+            ),
         ]
         self.assertEqual(set(mounts), set(expected_mounts))
+
 
 #        p = re.compile('\d+:\d+$')
 #        print 'Omitted devices:'

--- a/tests/device_plugins/test_linux_network.py
+++ b/tests/device_plugins/test_linux_network.py
@@ -1,7 +1,10 @@
 from collections import namedtuple
 from django.utils import unittest
 import mock
-from chroma_agent.device_plugins.linux_network import LinuxNetworkDevicePlugin, NetworkInterfaces
+from chroma_agent.device_plugins.linux_network import (
+    LinuxNetworkDevicePlugin,
+    NetworkInterfaces,
+)
 
 
 class TestLinuxNetwork(unittest.TestCase):
@@ -46,45 +49,97 @@ class TestLinuxNetwork(unittest.TestCase):
                 pass
 
             def readlines(self):
-                '''
+                """
                 The out of of a 'cat /proc/net/dev command.
                 :return: Returns a list of lines as readlines would.
-                '''
-                return ["Inter-|   Receive                                                |  Transmit",
-                        "face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed",
-                        "lo: 8305400   85521    0    0    0     0          0         0  8305401   85521    0    0    0     0       0          0",
-                        "bond0: 314203   2322    0    0    0     0          0         0  129834   82221    0    0    0     0       0          0",
-                        "eth0.1.1?1b34*430: 318398818 20564    0    0    0     0          0         0  2069564   50037    0    0    0     0       0          0",
-                        "eth4: 20400 6802    0    0    0     0          0         0  6859022   50337    0    0    0     0       0          0",
-                        "ib0: 3286081 4756    0    0    0     0          0         0  4753096   50237    0    0    0     0       0          0"]
+                """
+                return [
+                    "Inter-|   Receive                                                |  Transmit",
+                    "face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed",
+                    "lo: 8305400   85521    0    0    0     0          0         0  8305401   85521    0    0    0     0       0          0",
+                    "bond0: 314203   2322    0    0    0     0          0         0  129834   82221    0    0    0     0       0          0",
+                    "eth0.1.1?1b34*430: 318398818 20564    0    0    0     0          0         0  2069564   50037    0    0    0     0       0          0",
+                    "eth4: 20400 6802    0    0    0     0          0         0  6859022   50337    0    0    0     0       0          0",
+                    "ib0: 3286081 4756    0    0    0     0          0         0  4753096   50237    0    0    0     0       0          0",
+                ]
 
-        with mock.patch('__builtin__.open', mock_open):
-            with mock.patch('chroma_agent.lib.shell.AgentShell.try_run', self.mock_try_run):
+        with mock.patch("__builtin__.open", mock_open):
+            with mock.patch(
+                "chroma_agent.lib.shell.AgentShell.try_run", self.mock_try_run
+            ):
                 interfaces = NetworkInterfaces()
 
-        ResultCheck = namedtuple("ResultCheck",
-                                 ["interface", "mac_address", "type", "inet4_addr", "inet4_prefix", "inet6_addr",
-                                 "rx_bytes", "tx_bytes", "up", "slave"])
+        ResultCheck = namedtuple(
+            "ResultCheck",
+            [
+                "interface",
+                "mac_address",
+                "type",
+                "inet4_addr",
+                "inet4_prefix",
+                "inet6_addr",
+                "rx_bytes",
+                "tx_bytes",
+                "up",
+                "slave",
+            ],
+        )
 
         self.assertEqual(len(interfaces), 5)
 
-        for result_check in [ResultCheck("bond0", "52:54:00:33:d9:15", "tcp", "192.168.10.79", 21, "fe80::4e00:10ff:feac:61e0", "314203", "129834", True, False),
-                             ResultCheck("eth2", "52:54:00:33:a7:11", "tcp", "", 0, "", "0", "0", False, False),
-                             ResultCheck("eth4", "52:54:00:33:a7:15", "tcp", "10.0.0.101", 24, "fe80::200:ff:fe00:2", "20400", "6859022", True, False),
-                             ResultCheck("ib0", "80:00:00:48:FE:80:00:00:00:00:00:00:00:00:00:00:00:00:00:00",
-                                         "o2ib", "192.168.4.23", 23, "fe80::225:90ff:ff1c:a229", "3286081", "4753096", True, False)]:
+        for result_check in [
+            ResultCheck(
+                "bond0",
+                "52:54:00:33:d9:15",
+                "tcp",
+                "192.168.10.79",
+                21,
+                "fe80::4e00:10ff:feac:61e0",
+                "314203",
+                "129834",
+                True,
+                False,
+            ),
+            ResultCheck(
+                "eth2", "52:54:00:33:a7:11", "tcp", "", 0, "", "0", "0", False, False
+            ),
+            ResultCheck(
+                "eth4",
+                "52:54:00:33:a7:15",
+                "tcp",
+                "10.0.0.101",
+                24,
+                "fe80::200:ff:fe00:2",
+                "20400",
+                "6859022",
+                True,
+                False,
+            ),
+            ResultCheck(
+                "ib0",
+                "80:00:00:48:FE:80:00:00:00:00:00:00:00:00:00:00:00:00:00:00",
+                "o2ib",
+                "192.168.4.23",
+                23,
+                "fe80::225:90ff:ff1c:a229",
+                "3286081",
+                "4753096",
+                True,
+                False,
+            ),
+        ]:
 
             interface = interfaces[result_check.interface]
 
-            self.assertEqual(interface['mac_address'], result_check.mac_address)
-            self.assertEqual(interface['type'], result_check.type)
-            self.assertEqual(interface['inet4_address'], result_check.inet4_addr)
-            self.assertEqual(interface['inet4_prefix'], result_check.inet4_prefix)
-            self.assertEqual(interface['inet6_address'], result_check.inet6_addr)
-            self.assertEqual(interface['rx_bytes'], result_check.rx_bytes)
-            self.assertEqual(interface['tx_bytes'], result_check.tx_bytes)
-            self.assertEqual(interface['up'], result_check.up)
-            self.assertEqual(interface['slave'], result_check.slave)
+            self.assertEqual(interface["mac_address"], result_check.mac_address)
+            self.assertEqual(interface["type"], result_check.type)
+            self.assertEqual(interface["inet4_address"], result_check.inet4_addr)
+            self.assertEqual(interface["inet4_prefix"], result_check.inet4_prefix)
+            self.assertEqual(interface["inet6_address"], result_check.inet6_addr)
+            self.assertEqual(interface["rx_bytes"], result_check.rx_bytes)
+            self.assertEqual(interface["tx_bytes"], result_check.tx_bytes)
+            self.assertEqual(interface["up"], result_check.up)
+            self.assertEqual(interface["slave"], result_check.slave)
 
         return interfaces
 
@@ -100,44 +155,122 @@ class TestLinuxNetwork(unittest.TestCase):
                 pass
 
             def readlines(self):
-                '''
+                """
                 The out of of a 'cat /proc/sys/lnet/nis commaned. I have seen returns with the same entry
                 repeated many times, hences its inclusion.
                 :return: Returns a list of lines as readlines would.
-                '''
-                return ["nid                      status alive refs peer  rtr   max    tx   min",
-                        "0@lo                         up     0    3    0    0     0     0     0",
-                        "192.168.10.79@tcp1001        up    -1    1    8    0   256   256   256",
-                        "192.168.10.78@tcp1002        up    -1    1    8    0   256   256   256",
-                        "10.0.0.101@tcp1              up    -1    1    8    0   256   256   256",
-                        "192.168.4.23@o2ib99          up    -1    1    8    0   256   256   256",
-                        "192.168.4.23@o2ib99          up    -1    1    8    0   256   256   256",
-                        "192.168.4.23@o2ib99          up    -1    1    8    0   256   256   256",
-                        "192.168.4.23@o2ib99          up    -1    1    8    0   256   256   256",
-                        "192.168.4.23@o2ib99          up    -1    1    8    0   256   256   256",
-                        "192.168.4.23@o2ib99          up    -1    1    8    0   256   256   256"]
+                """
+                return [
+                    "nid                      status alive refs peer  rtr   max    tx   min",
+                    "0@lo                         up     0    3    0    0     0     0     0",
+                    "192.168.10.79@tcp1001        up    -1    1    8    0   256   256   256",
+                    "192.168.10.78@tcp1002        up    -1    1    8    0   256   256   256",
+                    "10.0.0.101@tcp1              up    -1    1    8    0   256   256   256",
+                    "192.168.4.23@o2ib99          up    -1    1    8    0   256   256   256",
+                    "192.168.4.23@o2ib99          up    -1    1    8    0   256   256   256",
+                    "192.168.4.23@o2ib99          up    -1    1    8    0   256   256   256",
+                    "192.168.4.23@o2ib99          up    -1    1    8    0   256   256   256",
+                    "192.168.4.23@o2ib99          up    -1    1    8    0   256   256   256",
+                    "192.168.4.23@o2ib99          up    -1    1    8    0   256   256   256",
+                ]
 
-        with mock.patch('__builtin__.open', mock_open):
-                device_plugin = LinuxNetworkDevicePlugin(None)
-                interfaces = self.test_network_interface()
-                lnet_devices = device_plugin._lnet_devices(interfaces)
+        with mock.patch("__builtin__.open", mock_open):
+            device_plugin = LinuxNetworkDevicePlugin(None)
+            interfaces = self.test_network_interface()
+            lnet_devices = device_plugin._lnet_devices(interfaces)
 
-        ResultCheck = namedtuple("ResultCheck",
-                                 ["name", "lnd_address", "lnd_network", "lnd_type", "status", "alive", "refs", "peer", "rtr", "max", "tx", "min", "present"])
+        ResultCheck = namedtuple(
+            "ResultCheck",
+            [
+                "name",
+                "lnd_address",
+                "lnd_network",
+                "lnd_type",
+                "status",
+                "alive",
+                "refs",
+                "peer",
+                "rtr",
+                "max",
+                "tx",
+                "min",
+                "present",
+            ],
+        )
 
         self.assertEqual(len(lnet_devices), 3)
 
-        for result_check in [ResultCheck("lo",    "0",             "0",    "tcp",  "up", "0",  "3", "0", "0",  "0",  "0",    "0",  False),
-                             ResultCheck("bond0", "192.168.10.79", "1001", "tcp",  "up", "-1", "1", "8", "0", "256", "256", "256", True),
-                             ResultCheck("fake",  "192.168.10.78", "1002", "tcp",  "up", "-1", "1", "8", "0", "256", "256", "256", False),
-                             ResultCheck("eth4",  "10.0.0.101",    "1",    "tcp",  "up", "-1", "1", "8", "0", "256", "256", "256", True),
-                             ResultCheck("ib0",   "192.168.4.23",  "99",   "o2ib", "up", "-1", "1", "8", "0", "256", "256", "256", True)]:
+        for result_check in [
+            ResultCheck(
+                "lo", "0", "0", "tcp", "up", "0", "3", "0", "0", "0", "0", "0", False
+            ),
+            ResultCheck(
+                "bond0",
+                "192.168.10.79",
+                "1001",
+                "tcp",
+                "up",
+                "-1",
+                "1",
+                "8",
+                "0",
+                "256",
+                "256",
+                "256",
+                True,
+            ),
+            ResultCheck(
+                "fake",
+                "192.168.10.78",
+                "1002",
+                "tcp",
+                "up",
+                "-1",
+                "1",
+                "8",
+                "0",
+                "256",
+                "256",
+                "256",
+                False,
+            ),
+            ResultCheck(
+                "eth4",
+                "10.0.0.101",
+                "1",
+                "tcp",
+                "up",
+                "-1",
+                "1",
+                "8",
+                "0",
+                "256",
+                "256",
+                "256",
+                True,
+            ),
+            ResultCheck(
+                "ib0",
+                "192.168.4.23",
+                "99",
+                "o2ib",
+                "up",
+                "-1",
+                "1",
+                "8",
+                "0",
+                "256",
+                "256",
+                "256",
+                True,
+            ),
+        ]:
             try:
                 nid = lnet_devices[result_check.name]
             except KeyError:
                 self.assertEqual(result_check.present, False)
                 continue
 
-            self.assertEqual(nid['nid_address'], result_check.lnd_address)
-            self.assertEqual(nid['lnd_network'], result_check.lnd_network)
-            self.assertEqual(nid['lnd_type'], result_check.lnd_type)
+            self.assertEqual(nid["nid_address"], result_check.lnd_address)
+            self.assertEqual(nid["lnd_network"], result_check.lnd_network)
+            self.assertEqual(nid["lnd_type"], result_check.lnd_type)

--- a/tests/device_plugins/test_lustre.py
+++ b/tests/device_plugins/test_lustre.py
@@ -6,56 +6,70 @@ from tests.lib.agent_unit_testcase import AgentUnitTestCase
 from chroma_agent.device_plugins.lustre import LustrePlugin
 
 
-class MockLocalAudit():
+class MockLocalAudit:
     def metrics(self):
-        return {'metrics': TestLustreAudit.values['metrics']}
+        return {"metrics": TestLustreAudit.values["metrics"]}
 
     def properties(self):
-        return {'properties': TestLustreAudit.values['properties']}
+        return {"properties": TestLustreAudit.values["properties"]}
 
 
-class MockActionPluginManager():
+class MockActionPluginManager:
     capabilities = 0
     pass
 
 
 class TestLustreAudit(AgentUnitTestCase):
     def mock_capabilities(self):
-        return {'capabilities': TestLustreAudit.values['capabilities']}
+        return {"capabilities": TestLustreAudit.values["capabilities"]}
 
     def mock_get_resource_locations(self):
-        return {'resource locations': TestLustreAudit.values['resource_locations']}
+        return {"resource locations": TestLustreAudit.values["resource_locations"]}
 
     def mock_scan_mounts(self):
-        return {'scan_mounts': TestLustreAudit.values['scan_mounts']}
+        return {"scan_mounts": TestLustreAudit.values["scan_mounts"]}
 
     def setUp(self):
         super(TestLustreAudit, self).setUp()
 
         self.addCleanup(mock.patch.stopall)
 
-        TestLustreAudit.values = {'capabilities': True,
-                                 'resource_locations': True,
-                                 'scan_mounts': True,
-                                 'metrics': True,
-                                 'properties': True}
+        TestLustreAudit.values = {
+            "capabilities": True,
+            "resource_locations": True,
+            "scan_mounts": True,
+            "metrics": True,
+            "properties": True,
+        }
 
-        mock.patch('chroma_agent.plugin_manager.ActionPluginManager',
-                   MockActionPluginManager).start()
+        mock.patch(
+            "chroma_agent.plugin_manager.ActionPluginManager", MockActionPluginManager
+        ).start()
 
-        mock.patch('chroma_agent.action_plugins.manage_targets.get_resource_locations',
-                   self.mock_get_resource_locations).start()
+        mock.patch(
+            "chroma_agent.action_plugins.manage_targets.get_resource_locations",
+            self.mock_get_resource_locations,
+        ).start()
 
-        mock.patch('chroma_agent.device_plugins.audit.local.LocalAudit',
-                   MockLocalAudit).start()
+        mock.patch(
+            "chroma_agent.device_plugins.audit.local.LocalAudit", MockLocalAudit
+        ).start()
 
-        mock.patch('chroma_agent.device_plugins.lustre.LustrePlugin._scan_mounts',
-                   self.mock_scan_mounts).start()
+        mock.patch(
+            "chroma_agent.device_plugins.lustre.LustrePlugin._scan_mounts",
+            self.mock_scan_mounts,
+        ).start()
 
         self.lustre_plugin = LustrePlugin(None)
 
     def test_audit_delta_match(self):
-        delta_fields = ['capabilities', 'properties', 'mounts', 'packages', 'resource_locations']
+        delta_fields = [
+            "capabilities",
+            "properties",
+            "mounts",
+            "packages",
+            "resource_locations",
+        ]
 
         result_all = self.lustre_plugin.update_session()
         result_none = self.lustre_plugin.update_session()
@@ -65,7 +79,7 @@ class TestLustreAudit(AgentUnitTestCase):
                 self.assertEqual(result_none[key], None)
             else:
                 # Time is a special case.
-                if key == 'started_at':
+                if key == "started_at":
                     self.assertGreater(result_none[key], result_all[key])
                 else:
                     self.assertEqual(result_all[key], result_none[key])
@@ -80,9 +94,9 @@ class TestLustreAudit(AgentUnitTestCase):
 
         for key in result_all:
             # Time and version and packages are a special case.
-            if key == 'started_at':
+            if key == "started_at":
                 self.assertGreater(result_match[key], result_all[key])
-            elif key not in ['agent_version', 'packages']:
+            elif key not in ["agent_version", "packages"]:
                 self.assertNotEqual(result_all[key], result_match[key])
 
     def test_audit_failsafe(self):
@@ -93,7 +107,7 @@ class TestLustreAudit(AgentUnitTestCase):
 
         for key in result_all:
             # Time is a special case.
-            if key == 'started_at':
+            if key == "started_at":
                 self.assertGreater(result_none[key], result_all[key])
             else:
                 self.assertEqual(result_all[key], result_none[key])

--- a/tests/lib/agent_unit_testcase.py
+++ b/tests/lib/agent_unit_testcase.py
@@ -10,13 +10,13 @@ class AgentUnitTestCase(unittest.TestCase):
     def setUp(self):
         self.addCleanup(mock.patch.stopall)
 
-        mock.patch.object(util, 'platform_info', util.PlatformInfo('Linux',
-                                                                   'CentOS',
-                                                                   7.2,
-                                                                   '7.21552',
-                                                                   2.7,
-                                                                   7,
-                                                                   '3.10.0-327.36.3.el7.x86_64')).start()
+        mock.patch.object(
+            util,
+            "platform_info",
+            util.PlatformInfo(
+                "Linux", "CentOS", 7.2, "7.21552", 2.7, 7, "3.10.0-327.36.3.el7.x86_64"
+            ),
+        ).start()
 
     def assertAgentOK(self, value):
         self.assertEqual(value, agent_result_ok)

--- a/tests/metrics/test_lustre.py
+++ b/tests/metrics/test_lustre.py
@@ -5,7 +5,13 @@ import os
 import shutil
 
 from chroma_agent.device_plugins.audit.local import LocalAudit
-from chroma_agent.device_plugins.audit.lustre import LnetAudit, MdtAudit, MgsAudit, ObdfilterAudit, DISABLE_BRW_STATS
+from chroma_agent.device_plugins.audit.lustre import (
+    LnetAudit,
+    MdtAudit,
+    MgsAudit,
+    ObdfilterAudit,
+    DISABLE_BRW_STATS,
+)
 
 from tests.test_utils import PatchedContextTestCase
 from iml_common.test.command_capture_testcase import CommandCaptureTestCase
@@ -16,75 +22,87 @@ lctl_output = "lov.lustre-MDT0000-mdtlov.target_obd=\n0: lustre-OST0000_UUID INA
 
 class TestLocalLustreMetrics(CommandCaptureTestCase, PatchedContextTestCase):
     def setUp(self):
-        self.tests = os.path.join(os.path.dirname(__file__), '..')
+        self.tests = os.path.join(os.path.dirname(__file__), "..")
         super(TestLocalLustreMetrics, self).setUp()
 
     def test_mdsmgs_metrics(self):
         """ Test that the various MGS/MDS metrics are collected and aggregated. """
-        self.test_root = os.path.join(self.tests,
-                                      "data/lustre_versions/2.9.58_86_g2383a62/mds_mgs")
+        self.test_root = os.path.join(
+            self.tests, "data/lustre_versions/2.9.58_86_g2383a62/mds_mgs"
+        )
 
         audit = LocalAudit()
 
         self.add_command(CMD, stdout=lctl_output)
 
-        metrics = audit.metrics()['raw']['lustre']
-        self.assertEqual(metrics['target']['testfs-MDT0000']['filesfree'], 4194037)
-        self.assertEqual(metrics['target']['MGS']['num_exports'], 6)
-        self.assertEqual(metrics['lnet']['send_count'], 12868)
+        metrics = audit.metrics()["raw"]["lustre"]
+        self.assertEqual(metrics["target"]["testfs-MDT0000"]["filesfree"], 4194037)
+        self.assertEqual(metrics["target"]["MGS"]["num_exports"], 6)
+        self.assertEqual(metrics["lnet"]["send_count"], 12868)
 
     def test_mdt_hsm_metrics(self):
         """ Test that the HSM metrics are collected and aggregated. """
-        self.test_root = os.path.join(self.tests,
-                                      "data/lustre_versions/2.9.58_86_g2383a62/mds_mgs")
+        self.test_root = os.path.join(
+            self.tests, "data/lustre_versions/2.9.58_86_g2383a62/mds_mgs"
+        )
 
         audit = LocalAudit()
 
         self.add_command(CMD, stdout=lctl_output)
 
-        metrics = audit.metrics()['raw']['lustre']['target']['testfs-MDT0000']['hsm']
-        self.assertEqual(metrics['agents']['idle'], 1)
-        self.assertEqual(metrics['agents']['busy'], 1)
-        self.assertEqual(metrics['agents']['total'], 2)
+        metrics = audit.metrics()["raw"]["lustre"]["target"]["testfs-MDT0000"]["hsm"]
+        self.assertEqual(metrics["agents"]["idle"], 1)
+        self.assertEqual(metrics["agents"]["busy"], 1)
+        self.assertEqual(metrics["agents"]["total"], 2)
 
-        self.assertEqual(metrics['actions']['waiting'], 1)
-        self.assertEqual(metrics['actions']['running'], 1)
-        self.assertEqual(metrics['actions']['succeeded'], 1)
-        self.assertEqual(metrics['actions']['errored'], 0)
+        self.assertEqual(metrics["actions"]["waiting"], 1)
+        self.assertEqual(metrics["actions"]["running"], 1)
+        self.assertEqual(metrics["actions"]["succeeded"], 1)
+        self.assertEqual(metrics["actions"]["errored"], 0)
 
     def test_oss_metrics(self):
         """Test that the various OSS metrics are collected and aggregated."""
-        self.test_root = os.path.join(self.tests,
-                                      "data/lustre_versions/2.9.58_86_g2383a62/oss")
+        self.test_root = os.path.join(
+            self.tests, "data/lustre_versions/2.9.58_86_g2383a62/oss"
+        )
 
         audit = LocalAudit()
-        metrics = audit.metrics()['raw']['lustre']
-        self.assertEqual(metrics['target']['testfs-OST0000']['filesfree'], 655061)
-        self.assertEqual(metrics['lnet']['recv_count'], 50072)
-        self.assertEqual(len(metrics['target']), 1)
+        metrics = audit.metrics()["raw"]["lustre"]
+        self.assertEqual(metrics["target"]["testfs-OST0000"]["filesfree"], 655061)
+        self.assertEqual(metrics["lnet"]["recv_count"], 50072)
+        self.assertEqual(len(metrics["target"]), 1)
 
-#    def test_24_oss_metrics(self):
-#        """Test that the various OSS metrics are collected and aggregated (2.4+)."""
-#        self.test_root = os.path.join(self.tests,
-#                                      "data/lustre_versions/2.9.58_86_g2383a62/oss")
-#
-#        audit = LocalAudit()
-#        metrics = audit.metrics()['raw']['lustre']
-#        self.assertEqual(metrics['target']['testfs-OST0000']['filesfree'], 655061)
-#        self.assertEqual(metrics['lnet']['recv_count'], 50072)
-#        self.assertEqual(len(metrics['target']), 1)
+    #    def test_24_oss_metrics(self):
+    #        """Test that the various OSS metrics are collected and aggregated (2.4+)."""
+    #        self.test_root = os.path.join(self.tests,
+    #                                      "data/lustre_versions/2.9.58_86_g2383a62/oss")
+    #
+    #        audit = LocalAudit()
+    #        metrics = audit.metrics()['raw']['lustre']
+    #        self.assertEqual(metrics['target']['testfs-OST0000']['filesfree'], 655061)
+    #        self.assertEqual(metrics['lnet']['recv_count'], 50072)
+    #        self.assertEqual(len(metrics['target']), 1)
 
     def test_stats(self):
         """ Test that expected values are provided for certain stats used by the UI. """
-        self.test_root = os.path.join(self.tests,
-                                      "data/lustre_versions/2.9.58_86_g2383a62/oss")
+        self.test_root = os.path.join(
+            self.tests, "data/lustre_versions/2.9.58_86_g2383a62/oss"
+        )
 
         audit = LocalAudit()
-        metrics = audit.metrics()['raw']['lustre']
-        self.assertEqual(metrics['target']['testfs-OST0000']['stats']['read_bytes']['units'], "bytes")
-        self.assertEqual(metrics['target']['testfs-OST0000']['stats']['read_bytes']['sum'], 0)
-        self.assertEqual(metrics['target']['testfs-OST0000']['stats']['write_bytes']['count'], 2)
-        self.assertEqual(metrics['target']['testfs-OST0000']['stats']['write_bytes']['sum'], 2468000)
+        metrics = audit.metrics()["raw"]["lustre"]
+        self.assertEqual(
+            metrics["target"]["testfs-OST0000"]["stats"]["read_bytes"]["units"], "bytes"
+        )
+        self.assertEqual(
+            metrics["target"]["testfs-OST0000"]["stats"]["read_bytes"]["sum"], 0
+        )
+        self.assertEqual(
+            metrics["target"]["testfs-OST0000"]["stats"]["write_bytes"]["count"], 2
+        )
+        self.assertEqual(
+            metrics["target"]["testfs-OST0000"]["stats"]["write_bytes"]["sum"], 2468000
+        )
 
 
 class TestPathologicalUseCases(PatchedContextTestCase):
@@ -110,9 +128,11 @@ class TestPathologicalUseCases(PatchedContextTestCase):
         os.makedirs(os.path.join(self.test_root, "proc/sys/lnet"))
 
         f = open(os.path.join(self.test_root, "proc/modules"), "w+")
-        f.write("""
+        f.write(
+            """
 lnet 233888 3 ptlrpc,ksocklnd,obdclass, Live 0xffffffffa076e000
-        """)
+        """
+        )
         f.close()
 
         # Create dummy nodestats files
@@ -166,16 +186,20 @@ lnet 233888 3 ptlrpc,ksocklnd,obdclass, Live 0xffffffffa076e000
 
         # Create a modules file with...  I dunno, lnet and mgs entries.
         f = open(os.path.join(self.test_root, "proc/modules"), "w+")
-        f.write("""
+        f.write(
+            """
 lnet 233888 3 ptlrpc,ksocklnd,obdclass, Live 0xffffffffa076e000
 exportfs 4202 1 fsfilt_ldiskfs, Live 0xffffffffa0d22000
 mgs 153919 1 - Live 0xffffffffa0cfa000
 mgc 50620 2 mgs, Live 0xffffffffa0a90000
-        """)
+        """
+        )
         f.close()
 
         # Create an empty devices file
-        open(os.path.join(self.test_root, "sys/kernel/debug/lustre/devices"), "w+").close()
+        open(
+            os.path.join(self.test_root, "sys/kernel/debug/lustre/devices"), "w+"
+        ).close()
 
         # Ideally, our audit aggregator should never instantiate the
         # audit in the first place.
@@ -192,7 +216,8 @@ mgc 50620 2 mgs, Live 0xffffffffa0a90000
 
         # Create a modules file with no Lustre modules in it.
         f = open(os.path.join(self.test_root, "proc/modules"), "w+")
-        f.write("""
+        f.write(
+            """
 lockd 74268 1 nfs, Live 0xffffffffa0105000
 fscache 46761 1 nfs, Live 0xffffffffa00ef000 (T)
 nfs_acl 2613 1 nfs, Live 0xffffffffa00e9000
@@ -203,7 +228,8 @@ crc_t10dif 1507 1 sd_mod, Live 0xffffffffa0065000
 e1000 167605 0 - Live 0xffffffffa0030000
 ahci 40197 5 - Live 0xffffffffa001e000
 dm_mod 75539 2 dm_mirror,dm_log, Live 0xffffffffa0000000
-        """)
+        """
+        )
         f.close()
 
         # Create dummy nodestats files
@@ -217,109 +243,141 @@ dm_mod 75539 2 dm_mirror,dm_log, Live 0xffffffffa0000000
         audit = LocalAudit()
         # FIXME: this gethostname() should probably be stubbed out
         import socket
-        self.assertEqual(audit.metrics(), {'raw': {'node': {'hostname': socket.gethostname(), 'cpustats': {'iowait': 10892, 'idle': 3471279, 'total': 3540537, 'user': 24601, 'system': 33763}, 'meminfo': {'MemTotal': 3991680}}}})
+
+        self.assertEqual(
+            audit.metrics(),
+            {
+                "raw": {
+                    "node": {
+                        "hostname": socket.gethostname(),
+                        "cpustats": {
+                            "iowait": 10892,
+                            "idle": 3471279,
+                            "total": 3540537,
+                            "user": 24601,
+                            "system": 33763,
+                        },
+                        "meminfo": {"MemTotal": 3991680},
+                    }
+                }
+            },
+        )
 
 
 class TestMdtMetrics(CommandCaptureTestCase, PatchedContextTestCase):
     def setUp(self):
-        tests = os.path.join(os.path.dirname(__file__), '..')
-        self.test_root = os.path.join(tests, "data/lustre_versions/2.9.58_86_g2383a62/mds_mgs")
+        tests = os.path.join(os.path.dirname(__file__), "..")
+        self.test_root = os.path.join(
+            tests, "data/lustre_versions/2.9.58_86_g2383a62/mds_mgs"
+        )
         super(TestMdtMetrics, self).setUp()
         self.audit = MdtAudit()
         self.add_command(CMD, stdout=lctl_output)
-        self.metrics = self.audit.metrics()['raw']['lustre']['target']
+        self.metrics = self.audit.metrics()["raw"]["lustre"]["target"]
 
     def test_get_client_count(self):
-        self.assertEqual(self.metrics['testfs-MDT0000']['client_count'], 1)
+        self.assertEqual(self.metrics["testfs-MDT0000"]["client_count"], 1)
 
     def test_mdt_stats_list(self):
         """Test that a representative sample of mdt stats is collected."""
-        stats_list = "req_waittime " \
-                     "req_qdepth " \
-                     "req_active " \
-                     "req_timeout " \
-                     "reqbuf_avail " \
-                     "ldlm_ibits_enqueue " \
-                     "mds_reint_setattr " \
-                     "mds_reint_open " \
-                     "mds_getattr " \
-                     "mds_connect " \
-                     "mds_get_root " \
-                     "mds_statfs " \
-                     "mds_getxattr " \
-                     "obd_ping " \
-                     "open " \
-                     "close " \
-                     "mknod " \
-                     "getattr " \
-                     "setattr " \
-                     "statfs " \
-                     "getxattr".split()
+        stats_list = (
+            "req_waittime "
+            "req_qdepth "
+            "req_active "
+            "req_timeout "
+            "reqbuf_avail "
+            "ldlm_ibits_enqueue "
+            "mds_reint_setattr "
+            "mds_reint_open "
+            "mds_getattr "
+            "mds_connect "
+            "mds_get_root "
+            "mds_statfs "
+            "mds_getxattr "
+            "obd_ping "
+            "open "
+            "close "
+            "mknod "
+            "getattr "
+            "setattr "
+            "statfs "
+            "getxattr".split()
+        )
         for stat in stats_list:
-            assert stat in self.metrics['testfs-MDT0000']['stats'].keys(), "%s is missing" % stat
+            assert stat in self.metrics["testfs-MDT0000"]["stats"].keys(), (
+                "%s is missing" % stat
+            )
 
     def test_mdt_stats_vals(self):
         """Test that the mdt stats contain the correct values."""
-        stats = self.metrics['testfs-MDT0000']['stats']
-        self.assertEqual(stats['mds_getattr']['units'], "usec")
-        self.assertEqual(stats['mds_get_root']['sum'], 15)
-        self.assertEqual(stats['mknod']['units'], "reqs")
-        self.assertEqual(stats['close']['count'], 8)
+        stats = self.metrics["testfs-MDT0000"]["stats"]
+        self.assertEqual(stats["mds_getattr"]["units"], "usec")
+        self.assertEqual(stats["mds_get_root"]["sum"], 15)
+        self.assertEqual(stats["mknod"]["units"], "reqs")
+        self.assertEqual(stats["close"]["count"], 8)
 
     def test_mdt_int_metrics(self):
         """Test that the mdt simple integer metrics are collected."""
         int_list = "client_count kbytestotal kbytesfree filestotal filesfree".split()
         for metric in int_list:
-            assert metric in self.metrics['testfs-MDT0000'].keys(), "%s is missing" % metric
+            assert metric in self.metrics["testfs-MDT0000"].keys(), (
+                "%s is missing" % metric
+            )
 
     def test_mdt_filesfree(self):
         """Test that mdt int metrics are sane."""
-        self.assertEqual(self.metrics['testfs-MDT0000']['filesfree'], 4194037)
+        self.assertEqual(self.metrics["testfs-MDT0000"]["filesfree"], 4194037)
 
 
 class TestLnetMetrics(PatchedContextTestCase):
     def setUp(self):
-        tests = os.path.join(os.path.dirname(__file__), '..')
-        self.test_root = os.path.join(tests, "data/lustre_versions/2.9.58_86_g2383a62/mds_mgs")
+        tests = os.path.join(os.path.dirname(__file__), "..")
+        self.test_root = os.path.join(
+            tests, "data/lustre_versions/2.9.58_86_g2383a62/mds_mgs"
+        )
         super(TestLnetMetrics, self).setUp()
         audit = LnetAudit()
         self.metrics = audit.metrics()
 
     def test_lnet_send_count(self):
         """Test that LNet metrics look sane."""
-        self.assertEqual(self.metrics['raw']['lustre']['lnet']['send_count'], 12868)
+        self.assertEqual(self.metrics["raw"]["lustre"]["lnet"]["send_count"], 12868)
 
 
 class TestMgsMetrics(PatchedContextTestCase):
     def setUp(self):
-        tests = os.path.join(os.path.dirname(__file__), '..')
-        self.test_root = os.path.join(tests, "data/lustre_versions/2.9.58_86_g2383a62/mds_mgs")
+        tests = os.path.join(os.path.dirname(__file__), "..")
+        self.test_root = os.path.join(
+            tests, "data/lustre_versions/2.9.58_86_g2383a62/mds_mgs"
+        )
         super(TestMgsMetrics, self).setUp()
         audit = MgsAudit()
-        self.metrics = audit.metrics()['raw']['lustre']['target']['MGS']
+        self.metrics = audit.metrics()["raw"]["lustre"]["target"]["MGS"]
 
     def test_mgs_stats_list(self):
         """Test that a representative sample of mgs stats is collected."""
-        stats_list = "req_waittime " \
-                     "req_qdepth " \
-                     "req_active " \
-                     "req_timeout " \
-                     "reqbuf_avail " \
-                     "ldlm_plain_enqueue " \
-                     "mgs_connect " \
-                     "mgs_target_reg " \
-                     "mgs_config_read " \
-                     "obd_ping " \
-                     "llog_origin_handle_open " \
-                     "llog_origin_handle_next_block " \
-                     "llog_origin_handle_read_header".split()
+        stats_list = (
+            "req_waittime "
+            "req_qdepth "
+            "req_active "
+            "req_timeout "
+            "reqbuf_avail "
+            "ldlm_plain_enqueue "
+            "mgs_connect "
+            "mgs_target_reg "
+            "mgs_config_read "
+            "obd_ping "
+            "llog_origin_handle_open "
+            "llog_origin_handle_next_block "
+            "llog_origin_handle_read_header".split()
+        )
         for stat in stats_list:
-            assert stat in self.metrics['stats'].keys()
+            assert stat in self.metrics["stats"].keys()
 
     def test_mgs_stats_vals(self):
         """Test that the mgs stats contain the correct values."""
-        self.assertEqual(self.metrics['stats']['reqbuf_avail']['units'], "bufs")
-        self.assertEqual(self.metrics['stats']['mgs_connect']['sumsquare'], 380555157)
+        self.assertEqual(self.metrics["stats"]["reqbuf_avail"]["units"], "bufs")
+        self.assertEqual(self.metrics["stats"]["mgs_connect"]["sumsquare"], 380555157)
 
     def test_mgs_int_metrics(self):
         """Test that the mgs simple integer metrics are collected."""
@@ -329,88 +387,98 @@ class TestMgsMetrics(PatchedContextTestCase):
 
     def test_mgs_threads_max(self):
         """Test that mgs int metrics are sane."""
-        self.assertEqual(self.metrics['threads_max'], 32)
+        self.assertEqual(self.metrics["threads_max"], 32)
 
 
 class TestObdfilterMetrics(PatchedContextTestCase):
     def setUp(self):
-        tests = os.path.join(os.path.dirname(__file__), '..')
+        tests = os.path.join(os.path.dirname(__file__), "..")
         self.test_root = os.path.join(tests, "data/lustre_versions/2.9.58_jobstats/oss")
         super(TestObdfilterMetrics, self).setUp()
         audit = ObdfilterAudit()
-        self.metrics = audit.metrics()['raw']['lustre']['target']
+        self.metrics = audit.metrics()["raw"]["lustre"]["target"]
 
     def test_obdfilter_stats_list(self):
         """Test that a representative sample of obdfilter stats is collected."""
         stats_list = "read_bytes write_bytes get_page cache_access cache_hit cache_miss get_info set_info_async connect reconnect disconnect statfs create destroy punch sync preprw commitrw llog_init llog_connect ping".split()
         for stat in stats_list:
-            assert stat in self.metrics['lustre-OST0000']['stats'].keys()
+            assert stat in self.metrics["lustre-OST0000"]["stats"].keys()
 
     def test_obdfilter_stats_vals(self):
         """Test that the obdfilter stats contain the correct values."""
-        self.assertEqual(self.metrics['lustre-OST0000']['stats']['cache_hit']['units'], "pages")
-        self.assertEqual(self.metrics['lustre-OST0001']['stats']['write_bytes']['sum'], 15260975104)
-        self.assertEqual(self.metrics['lustre-OST0000']['stats']['read_bytes']['count'], 1892)
-        self.assertEqual(self.metrics['lustre-OST0001']['stats']['statfs']['count'], 14472)
+        self.assertEqual(
+            self.metrics["lustre-OST0000"]["stats"]["cache_hit"]["units"], "pages"
+        )
+        self.assertEqual(
+            self.metrics["lustre-OST0001"]["stats"]["write_bytes"]["sum"], 15260975104
+        )
+        self.assertEqual(
+            self.metrics["lustre-OST0000"]["stats"]["read_bytes"]["count"], 1892
+        )
+        self.assertEqual(
+            self.metrics["lustre-OST0001"]["stats"]["statfs"]["count"], 14472
+        )
 
     def test_obdfilter_int_metrics(self):
         """Test that the obdfilter simple integer metrics are collected."""
         int_list = "num_exports kbytestotal kbytesfree kbytesavail filestotal filesfree tot_dirty tot_granted tot_pending".split()
         for metric in int_list:
-            assert metric in self.metrics['lustre-OST0000'].keys()
+            assert metric in self.metrics["lustre-OST0000"].keys()
 
     def test_obdfilter_filestotal(self):
         """Test that obdfilter int metrics are sane."""
-        self.assertEqual(self.metrics['lustre-OST0001']['filestotal'], 128000)
+        self.assertEqual(self.metrics["lustre-OST0001"]["filestotal"], 128000)
 
     @skipIf(DISABLE_BRW_STATS, "BRW stats disabled because of HYD-2307")
     def test_obdfilter_brw_stats(self):
         """Test that obdfilter brw_stats are collected at all."""
-        assert 'brw_stats' in self.metrics['lustre-OST0000']
+        assert "brw_stats" in self.metrics["lustre-OST0000"]
 
     @skipIf(DISABLE_BRW_STATS, "BRW stats disabled because of HYD-2307")
     def test_obdfilter_brw_stats_histograms(self):
         """Test that obdfilter brw_stats are grouped by histograms."""
         hist_list = "pages discont_pages discont_blocks dio_frags rpc_hist io_time disk_iosize".split()
         for name in hist_list:
-            assert name in self.metrics['lustre-OST0000']['brw_stats'].keys()
+            assert name in self.metrics["lustre-OST0000"]["brw_stats"].keys()
 
     @skipIf(DISABLE_BRW_STATS, "BRW stats disabled because of HYD-2307")
     def test_obdfilter_brw_stats_hist_vals(self):
         """Test that obdfilter brw_stats contain sane values."""
-        hist = self.metrics['lustre-OST0000']['brw_stats']['disk_iosize']
-        self.assertEqual(hist['units'], "ios")
-        self.assertEqual(hist['buckets']['128K']['read']['count'], 784)
-        self.assertEqual(hist['buckets']['8K']['read']['pct'], 0)
-        self.assertEqual(hist['buckets']['64K']['read']['cum_pct'], 23)
+        hist = self.metrics["lustre-OST0000"]["brw_stats"]["disk_iosize"]
+        self.assertEqual(hist["units"], "ios")
+        self.assertEqual(hist["buckets"]["128K"]["read"]["count"], 784)
+        self.assertEqual(hist["buckets"]["8K"]["read"]["pct"], 0)
+        self.assertEqual(hist["buckets"]["64K"]["read"]["cum_pct"], 23)
 
-        hist = self.metrics['lustre-OST0000']['brw_stats']['discont_blocks']
-        self.assertEqual(hist['units'], "rpcs")
-        self.assertEqual(hist['buckets']['1']['write']['count'], 288)
-        self.assertEqual(hist['buckets']['17']['write']['pct'], 0)
-        self.assertEqual(hist['buckets']['31']['write']['cum_pct'], 100)
+        hist = self.metrics["lustre-OST0000"]["brw_stats"]["discont_blocks"]
+        self.assertEqual(hist["units"], "rpcs")
+        self.assertEqual(hist["buckets"]["1"]["write"]["count"], 288)
+        self.assertEqual(hist["buckets"]["17"]["write"]["pct"], 0)
+        self.assertEqual(hist["buckets"]["31"]["write"]["cum_pct"], 100)
 
     @skipIf(DISABLE_BRW_STATS, "BRW stats disabled because of HYD-2307")
     def test_obdfilter_brw_stats_empty_buckets(self):
         """Test that brw_stats hists on a fresh OST (no traffic) have empty buckets."""
-        hist = self.metrics['lustre-OST0003']['brw_stats']['pages']
-        self.assertEqual(hist['buckets'], {})
+        hist = self.metrics["lustre-OST0003"]["brw_stats"]["pages"]
+        self.assertEqual(hist["buckets"], {})
 
 
 class TestJobStats(PatchedContextTestCase):
     def setUp(self):
-        self.test_root = os.path.normpath(os.path.join(__file__, '../../data/lustre_versions/2.9.58_jobstats/oss'))
+        self.test_root = os.path.normpath(
+            os.path.join(__file__, "../../data/lustre_versions/2.9.58_jobstats/oss")
+        )
         super(TestJobStats, self).setUp()
         audit = ObdfilterAudit()
-        self.metrics = audit.metrics()['raw']['lustre']
+        self.metrics = audit.metrics()["raw"]["lustre"]
 
     def test(self):
-        assert self.metrics['jobid_var'] == 'procname_uid'
-        metrics = self.metrics['target']
-        for target in ('lustre-OST0001', 'lustre-OST0002', 'lustre-OST0003'):
-            assert metrics[target]['job_stats'] == []
-        stats = metrics['lustre-OST0000']['job_stats']
-        assert [stat['job_id'] for stat in stats] == ['dd.0', 'cp.0']
-        assert [stat['snapshot_time'] for stat in stats] == [1381939640, 1381939592]
-        assert stats[0]['read']['sum'] == stats[0]['write']['sum'] == 671088640
-        assert stats[1]['read']['sum'] == 0 and stats[1]['write']['sum'] == 220986046
+        assert self.metrics["jobid_var"] == "procname_uid"
+        metrics = self.metrics["target"]
+        for target in ("lustre-OST0001", "lustre-OST0002", "lustre-OST0003"):
+            assert metrics[target]["job_stats"] == []
+        stats = metrics["lustre-OST0000"]["job_stats"]
+        assert [stat["job_id"] for stat in stats] == ["dd.0", "cp.0"]
+        assert [stat["snapshot_time"] for stat in stats] == [1381939640, 1381939592]
+        assert stats[0]["read"]["sum"] == stats[0]["write"]["sum"] == 671088640
+        assert stats[1]["read"]["sum"] == 0 and stats[1]["write"]["sum"] == 220986046

--- a/tests/metrics/test_node.py
+++ b/tests/metrics/test_node.py
@@ -6,15 +6,17 @@ from tests.test_utils import PatchedContextTestCase
 
 class TestNodeMetrics(PatchedContextTestCase):
     def setUp(self):
-        tests = os.path.join(os.path.dirname(__file__), '..')
-        self.test_root = os.path.join(tests, "data/lustre_versions/2.9.58_86_g2383a62/mds_mgs")
+        tests = os.path.join(os.path.dirname(__file__), "..")
+        self.test_root = os.path.join(
+            tests, "data/lustre_versions/2.9.58_86_g2383a62/mds_mgs"
+        )
         super(TestNodeMetrics, self).setUp()
         self.audit = NodeAudit()
         self.metrics = self.audit.metrics()
 
     def test_node_cpustats(self):
-        self.assertEqual(self.metrics['raw']['node']['cpustats']['total'], 10309070)
-        self.assertEqual(self.metrics['raw']['node']['cpustats']['user'], 360581)
+        self.assertEqual(self.metrics["raw"]["node"]["cpustats"]["total"], 10309070)
+        self.assertEqual(self.metrics["raw"]["node"]["cpustats"]["user"], 360581)
 
     def test_node_meminfo(self):
-        self.assertEqual(self.metrics['raw']['node']['meminfo']['MemTotal'], 1883716)
+        self.assertEqual(self.metrics["raw"]["node"]["meminfo"]["MemTotal"], 1883716)

--- a/tests/test_agent_client.py
+++ b/tests/test_agent_client.py
@@ -6,9 +6,20 @@ import mock
 
 from django.utils import unittest
 
-from chroma_agent.agent_client import HttpWriter, Message, HttpReader, SessionTable, HttpError
+from chroma_agent.agent_client import (
+    HttpWriter,
+    Message,
+    HttpReader,
+    SessionTable,
+    HttpError,
+)
 from chroma_agent.log import daemon_log
-from chroma_agent.plugin_manager import PRIO_LOW, DevicePluginMessage, PRIO_NORMAL, PRIO_HIGH
+from chroma_agent.plugin_manager import (
+    PRIO_LOW,
+    DevicePluginMessage,
+    PRIO_NORMAL,
+    PRIO_HIGH,
+)
 from iml_common.lib.date_time import IMLDateTime
 
 
@@ -20,7 +31,7 @@ class TestHttpWriter(unittest.TestCase):
         client = mock.Mock()
         client._fqdn = "test_server"
         client.device_plugins = mock.Mock()
-        client.device_plugins.get_plugins = mock.Mock(return_value=['test_plugin'])
+        client.device_plugins.get_plugins = mock.Mock(return_value=["test_plugin"])
         client.boot_time = IMLDateTime.utcnow()
         client.start_time = IMLDateTime.utcnow()
 
@@ -32,7 +43,14 @@ class TestHttpWriter(unittest.TestCase):
                 writer = HttpWriter(client)
                 writer.start()
 
-                message = Message("DATA", "test_plugin", {'key1': 'val1'}, 'session_foo', 666, callback = callback)
+                message = Message(
+                    "DATA",
+                    "test_plugin",
+                    {"key1": "val1"},
+                    "session_foo",
+                    666,
+                    callback=callback,
+                )
                 writer.put(message)
 
                 TIMEOUT = 2
@@ -44,15 +62,21 @@ class TestHttpWriter(unittest.TestCase):
                         time.sleep(1)
                         i += 1
                         if i > TIMEOUT:
-                            raise RuntimeError("Timeout waiting for .post() and callback (%s %s)" % (client.post.call_count, callback.call_count))
+                            raise RuntimeError(
+                                "Timeout waiting for .post() and callback (%s %s)"
+                                % (client.post.call_count, callback.call_count)
+                            )
 
                 # Should have sent back the result
                 self.assertEqual(client.post.call_count, 1)
-                self.assertDictEqual(client.post.call_args[0][0], {
-                    'messages': [message.dump(client._fqdn)],
-                    'server_boot_time': client.boot_time.isoformat() + "Z",
-                    'client_start_time': client.start_time.isoformat() + "Z"
-                })
+                self.assertDictEqual(
+                    client.post.call_args[0][0],
+                    {
+                        "messages": [message.dump(client._fqdn)],
+                        "server_boot_time": client.boot_time.isoformat() + "Z",
+                        "client_start_time": client.start_time.isoformat() + "Z",
+                    },
+                )
 
                 # Should have invoked the callback
                 self.assertEqual(callback.call_count, 1)
@@ -75,11 +99,13 @@ class TestHttpWriter(unittest.TestCase):
 
         def inject_messages(*args, **kwargs):
             # A control plane message
-            writer.put(Message("SESSION_CREATE_REQUEST", "plugin_fuz", None, None, None))
+            writer.put(
+                Message("SESSION_CREATE_REQUEST", "plugin_fuz", None, None, None)
+            )
 
-            low_body = DevicePluginMessage('low', PRIO_LOW)
-            normal_body = DevicePluginMessage('normal', PRIO_NORMAL)
-            high_body = DevicePluginMessage('high', PRIO_HIGH)
+            low_body = DevicePluginMessage("low", PRIO_LOW)
+            normal_body = DevicePluginMessage("normal", PRIO_NORMAL)
+            high_body = DevicePluginMessage("high", PRIO_HIGH)
             writer.put(Message("DATA", "plugin_foo", low_body, "foo", 0))
             writer.put(Message("DATA", "plugin_bar", normal_body, "foo", 1))
             writer.put(Message("DATA", "plugin_baz", high_body, "foo", 2))
@@ -87,15 +113,15 @@ class TestHttpWriter(unittest.TestCase):
         inject_messages()
         writer.send()
         self.assertEqual(client.post.call_count, 1)
-        messages = client.post.call_args[0][0]['messages']
+        messages = client.post.call_args[0][0]["messages"]
 
         self.assertEqual(len(messages), 4)
         # First two messages (of equal priority) arrive in order or insertion
-        self.assertEqual(messages[0]['plugin'], 'plugin_fuz')
-        self.assertEqual(messages[1]['plugin'], 'plugin_baz')
+        self.assertEqual(messages[0]["plugin"], "plugin_fuz")
+        self.assertEqual(messages[1]["plugin"], "plugin_baz")
         # Remaining messages arrive in priority order
-        self.assertEqual(messages[2]['plugin'], 'plugin_bar')
-        self.assertEqual(messages[3]['plugin'], 'plugin_foo')
+        self.assertEqual(messages[2]["plugin"], "plugin_bar")
+        self.assertEqual(messages[3]["plugin"], "plugin_foo")
 
     def test_session_backoff(self):
         """Test that when messages to the manager are being dropped due to POST failure,
@@ -113,9 +139,13 @@ class TestHttpWriter(unittest.TestCase):
         TestPlugin = mock.Mock()
 
         mock_plugin_instance = mock.Mock()
-        mock_plugin_instance.start_session = mock.Mock(return_value={'foo': 'bar'})
-        client.device_plugins.get = mock.Mock(return_value=lambda(plugin_name): mock_plugin_instance)
-        client.device_plugins.get_plugins = mock.Mock(return_value={'test_plugin': TestPlugin})
+        mock_plugin_instance.start_session = mock.Mock(return_value={"foo": "bar"})
+        client.device_plugins.get = mock.Mock(
+            return_value=lambda _: mock_plugin_instance
+        )
+        client.device_plugins.get_plugins = mock.Mock(
+            return_value={"test_plugin": TestPlugin}
+        )
         client.sessions = SessionTable(client)
 
         client.post = mock.Mock(side_effect=HttpError())
@@ -125,13 +155,18 @@ class TestHttpWriter(unittest.TestCase):
 
         old_datetime = datetime.datetime
         try:
+
             def expect_message_at(t):
-                datetime.datetime.now = mock.Mock(return_value=t - datetime.timedelta(seconds = 0.1))
-                writer.poll('test_plugin')
+                datetime.datetime.now = mock.Mock(
+                    return_value=t - datetime.timedelta(seconds=0.1)
+                )
+                writer.poll("test_plugin")
                 self.assertEqual(writer._messages.qsize(), 0)
 
-                datetime.datetime.now = mock.Mock(return_value=t + datetime.timedelta(seconds = 0.1))
-                writer.poll('test_plugin')
+                datetime.datetime.now = mock.Mock(
+                    return_value=t + datetime.timedelta(seconds=0.1)
+                )
+                writer.poll("test_plugin")
                 self.assertEqual(writer._messages.qsize(), 1)
 
             datetime.datetime = mock.Mock()
@@ -141,19 +176,20 @@ class TestHttpWriter(unittest.TestCase):
             # =====================================
 
             # Poll should put some session creation messages
-            writer.poll('test_plugin')
+            writer.poll("test_plugin")
             self.assertEqual(writer._messages.qsize(), 1)
             # Another poll immediately after shouldn't add any messages (MIN_SESSION_BACKOFF hasn't passed)
-            writer.poll('test_plugin')
+            writer.poll("test_plugin")
             self.assertEqual(writer._messages.qsize(), 1)
 
             # Send should consume the messages, and they go to nowhere because the POST fails
             writer.send()
             client.post.assert_called_once()
-            self.assertEqual(len(client.post.call_args[0][0]['messages']), 1)
+            self.assertEqual(len(client.post.call_args[0][0]["messages"]), 1)
 
             # First time boundary: where the first repeat should happen
             from chroma_agent.agent_client import MIN_SESSION_BACKOFF
+
             t_1 = t_0 + MIN_SESSION_BACKOFF
 
             expect_message_at(t_1)
@@ -174,15 +210,19 @@ class TestHttpWriter(unittest.TestCase):
             writer.send()
 
             # HttpReader receives a response from the manager, and should reset the backoff counters.
-            reader._handle_messages([{
-                'type': 'SESSION_CREATE_RESPONSE',
-                'plugin': 'test_plugin',
-                'session_id': 'id_foo',
-                'session_seq': 0,
-                'body': {}
-            }])
+            reader._handle_messages(
+                [
+                    {
+                        "type": "SESSION_CREATE_RESPONSE",
+                        "plugin": "test_plugin",
+                        "session_id": "id_foo",
+                        "session_seq": 0,
+                        "body": {},
+                    }
+                ]
+            )
             self.assertEqual(len(client.sessions._sessions), 1)
-            session = client.sessions.get('test_plugin')
+            session = client.sessions.get("test_plugin")
 
             # State 3: POSTs start failing again, see delay again
             # ===================================================
@@ -191,8 +231,8 @@ class TestHttpWriter(unittest.TestCase):
             client.post = mock.Mock(side_effect=HttpError())
 
             # Poll will get a DATA message from initial_scan
-            session.initial_scan = mock.Mock(return_value={'foo': 'bar'})
-            writer.poll('test_plugin')
+            session.initial_scan = mock.Mock(return_value={"foo": "bar"})
+            writer.poll("test_plugin")
             session.initial_scan.assert_called_once()
             self.assertFalse(writer._messages.empty())
 
@@ -202,12 +242,12 @@ class TestHttpWriter(unittest.TestCase):
             self.assertEqual(len(client.sessions._sessions), 0)
 
             # Move to some point beyond the first backoff cycle
-            t_3 = t_0 + datetime.timedelta(seconds = 60)
+            t_3 = t_0 + datetime.timedelta(seconds=60)
             datetime.datetime.now = mock.Mock(return_value=t_3)
 
-            writer.poll('test_plugin')
+            writer.poll("test_plugin")
             self.assertEqual(writer._messages.qsize(), 1)
-            writer.poll('test_plugin')
+            writer.poll("test_plugin")
             self.assertEqual(writer._messages.qsize(), 1)
             writer.send()
             self.assertEqual(writer._messages.qsize(), 0)
@@ -224,11 +264,15 @@ class TestHttpWriter(unittest.TestCase):
         """
         # Monkey-patch this setting to a lower limit to make testing easier
         MAX_BYTES_PER_POST = 1024
-        from chroma_agent.agent_client import MAX_BYTES_PER_POST as LARGE_MAX_BYTES_PER_POST
+        from chroma_agent.agent_client import (
+            MAX_BYTES_PER_POST as LARGE_MAX_BYTES_PER_POST,
+        )
 
         def set_post_limit(size):
             import chroma_agent.agent_client
+
             chroma_agent.agent_client.MAX_BYTES_PER_POST = size
+
         self.addCleanup(set_post_limit, LARGE_MAX_BYTES_PER_POST)
         set_post_limit(MAX_BYTES_PER_POST)
 
@@ -248,30 +292,37 @@ class TestHttpWriter(unittest.TestCase):
         TestPlugin = mock.Mock()
 
         mock_plugin_instance = mock.Mock()
-        mock_plugin_instance.start_session = mock.Mock(return_value={'foo': 'bar'})
-        client.device_plugins.get = mock.Mock(return_value=lambda(plugin_name): mock_plugin_instance)
-        client.device_plugins.get_plugins = mock.Mock(return_value={'test_plugin': TestPlugin})
+        mock_plugin_instance.start_session = mock.Mock(return_value={"foo": "bar"})
+        client.device_plugins.get = mock.Mock(
+            return_value=lambda _: mock_plugin_instance
+        )
+        client.device_plugins.get_plugins = mock.Mock(
+            return_value={"test_plugin": TestPlugin}
+        )
         client.sessions = SessionTable(client)
 
         daemon_log.setLevel(logging.DEBUG)
 
         import string
         from random import choice
-        oversized_string = "".join(choice(string.printable) for i in range(MAX_BYTES_PER_POST))
+
+        oversized_string = "".join(
+            choice(string.printable) for i in range(MAX_BYTES_PER_POST)
+        )
 
         # There should be one message to set up the session
-        writer.poll('test_plugin')
+        writer.poll("test_plugin")
         self.assertTrue(writer.send())
         self.assertEqual(client.post.call_count, 1)
-        messages = client.post.call_args[0][0]['messages']
+        messages = client.post.call_args[0][0]["messages"]
         self.assertEqual(len(messages), 1)
-        self.assertEqual(messages[0]['type'], "SESSION_CREATE_REQUEST")
+        self.assertEqual(messages[0]["type"], "SESSION_CREATE_REQUEST")
         # Pretend we got a SESSION_CREATE_RESPONSE
-        client.sessions.create('test_plugin', 'id_foo')
+        client.sessions.create("test_plugin", "id_foo")
         self.assertEqual(len(client.sessions._sessions), 1)
 
         # Inject a normal and an oversized message
-        normal_body = DevicePluginMessage('normal', PRIO_NORMAL)
+        normal_body = DevicePluginMessage("normal", PRIO_NORMAL)
         oversized_body = DevicePluginMessage(oversized_string, PRIO_NORMAL)
         writer.put(Message("DATA", "test_plugin", normal_body, "id_foo", 0))
         writer.put(Message("DATA", "test_plugin", oversized_body, "id_foo", 1))
@@ -279,9 +330,9 @@ class TestHttpWriter(unittest.TestCase):
         # Only the normal message should get through
         self.assertTrue(writer.send())
         self.assertEqual(client.post.call_count, 2)
-        messages = client.post.call_args[0][0]['messages']
+        messages = client.post.call_args[0][0]["messages"]
         self.assertEqual(len(messages), 1)
-        self.assertEqual(messages[0]['type'], "DATA")
+        self.assertEqual(messages[0]["type"], "DATA")
 
         # The oversized message should be dropped and the session
         # terminated
@@ -291,12 +342,12 @@ class TestHttpWriter(unittest.TestCase):
 
         # However, we should eventually get a new session for the
         # offending plugin
-        writer.poll('test_plugin')
+        writer.poll("test_plugin")
         self.assertTrue(writer.send())
         self.assertEqual(client.post.call_count, 4)
-        messages = client.post.call_args[0][0]['messages']
+        messages = client.post.call_args[0][0]["messages"]
         self.assertEqual(len(messages), 1)
-        self.assertEqual(messages[0]['type'], "SESSION_CREATE_REQUEST")
+        self.assertEqual(messages[0]["type"], "SESSION_CREATE_REQUEST")
 
 
 class TestHttpReader(unittest.TestCase):
@@ -306,20 +357,24 @@ class TestHttpReader(unittest.TestCase):
 
         client.sessions = SessionTable(client)
         session = mock.Mock()
-        session.id = 'foo_id'
-        client.sessions._sessions['test_plugin'] = session
+        session.id = "foo_id"
+        client.sessions._sessions["test_plugin"] = session
 
         reader = HttpReader(client)
-        reader._handle_messages([{
-            'type': 'DATA',
-            'plugin': 'test_plugin',
-            'session_id': 'foo_id',
-            'session_seq': None,
-            'fqdn': 'test_server',
-            'body': {'body': 'foo'}
-        }])
+        reader._handle_messages(
+            [
+                {
+                    "type": "DATA",
+                    "plugin": "test_plugin",
+                    "session_id": "foo_id",
+                    "session_seq": None,
+                    "fqdn": "test_server",
+                    "body": {"body": "foo"},
+                }
+            ]
+        )
 
-        session.receive_message.assertCalledOnceWith({'body': 'foo'})
+        session.receive_message.assertCalledOnceWith({"body": "foo"})
 
     def test_data_message_exception(self):
         """Test that if receive_message raises an exception, the session is terminated"""
@@ -329,22 +384,26 @@ class TestHttpReader(unittest.TestCase):
 
         client.sessions = SessionTable(client)
         session = mock.Mock()
-        session.id = 'foo_id'
-        client.sessions._sessions['test_plugin'] = session
+        session.id = "foo_id"
+        client.sessions._sessions["test_plugin"] = session
 
-        session.receive_message = mock.Mock(side_effect = RuntimeError())
+        session.receive_message = mock.Mock(side_effect=RuntimeError())
 
         reader = HttpReader(client)
-        reader._handle_messages([{
-                                     'type': 'DATA',
-                                     'plugin': 'test_plugin',
-                                     'session_id': 'foo_id',
-                                     'session_seq': None,
-                                     'fqdn': 'test_server',
-                                     'body': {'body': 'foo'}
-                                 }])
+        reader._handle_messages(
+            [
+                {
+                    "type": "DATA",
+                    "plugin": "test_plugin",
+                    "session_id": "foo_id",
+                    "session_seq": None,
+                    "fqdn": "test_server",
+                    "body": {"body": "foo"},
+                }
+            ]
+        )
 
         # Should have called our teardown method
         session.teardown.assertCalledOnce()
         # Should have removed the session
-        self.assertNotIn('test_plugin', client.sessions._sessions)
+        self.assertNotIn("test_plugin", client.sessions._sessions)

--- a/tests/test_conf_params.py
+++ b/tests/test_conf_params.py
@@ -1,29 +1,28 @@
-
 from chroma_agent.action_plugins.manage_conf_params import set_conf_param
 from iml_common.test.command_capture_testcase import CommandCaptureTestCase
 
 
 class TestConfParams(CommandCaptureTestCase):
     def test_conf_param_not_none(self):
-        self.add_command(('lctl', 'conf_param', 'Rupert=1234'))
+        self.add_command(("lctl", "conf_param", "Rupert=1234"))
 
-        set_conf_param(key='Rupert', value=1234)
+        set_conf_param(key="Rupert", value=1234)
         self.assertRanAllCommandsInOrder()
 
     def test_conf_param_not_none_but_zero(self):
-        self.add_command(('lctl', 'conf_param', 'Stanley=0'))
+        self.add_command(("lctl", "conf_param", "Stanley=0"))
 
-        set_conf_param(key='Stanley', value=0)
+        set_conf_param(key="Stanley", value=0)
         self.assertRanAllCommandsInOrder()
 
     def test_conf_param_none(self):
-        self.add_command(('lctl', 'conf_param', '-d', 'Edgar'))
+        self.add_command(("lctl", "conf_param", "-d", "Edgar"))
 
-        set_conf_param(key='Edgar', value=None)
+        set_conf_param(key="Edgar", value=None)
         self.assertRanAllCommandsInOrder()
 
     def test_conf_param_none_default(self):
-        self.add_command(('lctl', 'conf_param', '-d', 'Edward'))
+        self.add_command(("lctl", "conf_param", "-d", "Edward"))
 
-        set_conf_param(key='Edward')
+        set_conf_param(key="Edward")
         self.assertRanAllCommandsInOrder()

--- a/tests/test_config_store.py
+++ b/tests/test_config_store.py
@@ -8,7 +8,11 @@ from mock import patch
 
 from django.utils import unittest
 
-from chroma_agent.config_store import ConfigStore, ConfigKeyExistsError, InvalidConfigIdentifier
+from chroma_agent.config_store import (
+    ConfigStore,
+    ConfigKeyExistsError,
+    InvalidConfigIdentifier,
+)
 
 
 class ConfigStoreTests(unittest.TestCase):
@@ -17,9 +21,13 @@ class ConfigStoreTests(unittest.TestCase):
 
         self.config = ConfigStore(tempfile.mkdtemp())
 
-        self.data = {'foo': 1, 'bar': "1", 'baz': ['qux', 'quux', 'corge'],
-                     'grault': {'garply': "waldo", 'fred': ['plugh', 'xyzzy']},
-                     'thud': False}
+        self.data = {
+            "foo": 1,
+            "bar": "1",
+            "baz": ["qux", "quux", "corge"],
+            "grault": {"garply": "waldo", "fred": ["plugh", "xyzzy"]},
+            "thud": False,
+        }
 
     def tearDown(self):
         super(ConfigStoreTests, self).tearDown()
@@ -36,7 +44,7 @@ class ConfigStoreTests(unittest.TestCase):
     def test_update(self):
         self.config.set("barfy", "cow", self.data)
 
-        self.data['thud'] = True
+        self.data["thud"] = True
         self.config.update("barfy", "cow", self.data)
         self.assertEqual(self.data, self.config.get("barfy", "cow"))
 
@@ -60,8 +68,8 @@ class ConfigStoreTests(unittest.TestCase):
             self.config.get("barfy", "cow")
 
     def test_get_nonexistent_section(self):
-        self.assertListEqual([], self.config.get_section_keys('foo'))
-        self.assertDictEqual({}, self.config.get_section('foo'))
+        self.assertListEqual([], self.config.get_section_keys("foo"))
+        self.assertDictEqual({}, self.config.get_section("foo"))
 
     def test_sections(self):
         maladies = ["barfy", "gassy", "sad", "grumpy"]
@@ -73,20 +81,22 @@ class ConfigStoreTests(unittest.TestCase):
     def test_get_section(self):
         self.config.set("barfy", "cow", self.data)
 
-        self.assertDictEqual({'cow': self.data},
-                             self.config.get_section("barfy"))
+        self.assertDictEqual({"cow": self.data}, self.config.get_section("barfy"))
 
     def test_get_all(self):
         maladies = ["barfy", "gassy", "sad", "grumpy"]
         for malady in maladies:
             self.config.set(malady, "cow", self.data)
 
-        self.assertDictEqual({
-            'barfy': {'cow': self.data},
-            'gassy': {'cow': self.data},
-            'sad': {'cow': self.data},
-            'grumpy': {'cow': self.data}
-            }, self.config.get_all())
+        self.assertDictEqual(
+            {
+                "barfy": {"cow": self.data},
+                "gassy": {"cow": self.data},
+                "sad": {"cow": self.data},
+                "grumpy": {"cow": self.data},
+            },
+            self.config.get_all(),
+        )
 
     def test_clear(self):
         maladies = ["barfy", "gassy", "sad", "grumpy"]
@@ -99,19 +109,20 @@ class ConfigStoreTests(unittest.TestCase):
     def test_bad_identifiers(self):
         badkey = object()
         with self.assertRaises(InvalidConfigIdentifier):
-            self.config.set('whoops', badkey, "foobar")
+            self.config.set("whoops", badkey, "foobar")
         with self.assertRaises(InvalidConfigIdentifier):
-            self.config.set(badkey, 'whoops', "foobar")
+            self.config.set(badkey, "whoops", "foobar")
 
     def test_unicode_identifiers(self):
-        test_id = u'should work'
-        self.config.set('ok', test_id, self.data)
-        self.assertDictEqual(self.data, self.config.get('ok', test_id))
-        self.config.set(test_id, 'ok', self.data)
-        self.assertDictEqual(self.data, self.config.get(test_id, 'ok'))
+        test_id = u"should work"
+        self.config.set("ok", test_id, self.data)
+        self.assertDictEqual(self.data, self.config.get("ok", test_id))
+        self.config.set(test_id, "ok", self.data)
+        self.assertDictEqual(self.data, self.config.get(test_id, "ok"))
 
     def test_thread_safety(self):
         import Queue
+
         config = self.config
         data = self.data
         testcase = self
@@ -129,7 +140,9 @@ class ConfigStoreTests(unittest.TestCase):
                     with self.config.lock:
                         self.config.set("barfy", "cow", self.data)
                         time.sleep(1)
-                        self.testcase.assertDictEqual(self.data, self.config.get("barfy", "cow"))
+                        self.testcase.assertDictEqual(
+                            self.data, self.config.get("barfy", "cow")
+                        )
                 except Exception as e:
                     exceptions.put(e)
 
@@ -155,12 +168,14 @@ class ConfigStoreTests(unittest.TestCase):
         b.join()
 
         with self.assertRaises(Queue.Empty):
-            raise RuntimeError("Thread safety check failed: %s" %
-                               exceptions.get(block=False))
+            raise RuntimeError(
+                "Thread safety check failed: %s" % exceptions.get(block=False)
+            )
 
     def test_multiprocess_safety(self):
         from multiprocessing import Queue
         from Queue import Empty
+
         config = self.config
         data = self.data
         testcase = self
@@ -178,7 +193,9 @@ class ConfigStoreTests(unittest.TestCase):
                     with self.config.lock:
                         self.config.set("barfy", "cow", self.data)
                         time.sleep(1)
-                        self.testcase.assertDictEqual(self.data, self.config.get("barfy", "cow"))
+                        self.testcase.assertDictEqual(
+                            self.data, self.config.get("barfy", "cow")
+                        )
                 except Exception as e:
                     exceptions.put(e)
 
@@ -204,22 +221,23 @@ class ConfigStoreTests(unittest.TestCase):
         b.join()
 
         with self.assertRaises(Empty):
-            raise RuntimeError("Multi-process safety check failed: %s" %
-                               exceptions.get(block=False))
+            raise RuntimeError(
+                "Multi-process safety check failed: %s" % exceptions.get(block=False)
+            )
 
     def test_profile_managed_true(self):
-        self.config.set('settings', 'profile', {'managed': True})
+        self.config.set("settings", "profile", {"managed": True})
         self.assertEqual(self.config.profile_managed, True)
 
     def test_profile_managed_false(self):
-        self.config.set('settings', 'profile', {'managed': False})
+        self.config.set("settings", "profile", {"managed": False})
         self.assertEqual(self.config.profile_managed, False)
 
     def test_profile_managed_missing_false_section(self):
         self.assertEqual(self.config.profile_managed, False)
 
     def test_profile_managed_missing_false_ket(self):
-        self.config.set('settings', 'profile', {'trevor': 'andy'})
+        self.config.set("settings", "profile", {"trevor": "andy"})
         self.assertEqual(self.config.profile_managed, False)
 
 
@@ -228,8 +246,8 @@ class AgentStoreConversionTests(unittest.TestCase):
         super(AgentStoreConversionTests, self).setUp()
 
         self.env_path_patch = patch(
-            'chroma_agent.conf.ENV_PATH',
-            new=tempfile.mkdtemp())
+            "chroma_agent.conf.ENV_PATH", new=tempfile.mkdtemp()
+        )
         self.env_path = self.env_path_patch.start()
         self.config = ConfigStore(tempfile.mkdtemp())
 
@@ -245,35 +263,38 @@ class AgentStoreConversionTests(unittest.TestCase):
         import json
         import string
 
-        self.old_server_conf = {'url': 'http://foo.bar.baz/'}
+        self.old_server_conf = {"url": "http://foo.bar.baz/"}
 
-        with open(os.path.join(self.config.path, 'server_conf'), 'w') as f:
+        with open(os.path.join(self.config.path, "server_conf"), "w") as f:
             json.dump(self.old_server_conf, f)
 
         self.old_target_configs = {}
         for i in xrange(0, 15):
-            bdev = '/dev/sd%s' % string.ascii_lowercase[i]
-            mntpt = '/mnt/target%04d' % i
+            bdev = "/dev/sd%s" % string.ascii_lowercase[i]
+            mntpt = "/mnt/target%04d" % i
             uuid_str = str(uuid.uuid4())
-            target_config = dict(bdev = bdev, mntpt = mntpt)
-            with open(os.path.join(self.config.path, uuid_str), 'w') as f:
+            target_config = dict(bdev=bdev, mntpt=mntpt)
+            with open(os.path.join(self.config.path, uuid_str), "w") as f:
                 json.dump(target_config, f)
             self.old_target_configs[uuid_str] = target_config
 
     def test_agentstore_conversion(self):
         with patch(
-                'chroma_agent.action_plugins.settings_management.config',
-                new=self.config):
+            "chroma_agent.action_plugins.settings_management.config", new=self.config
+        ):
             self._create_agentstore_config()
 
-            from chroma_agent.action_plugins.settings_management import _convert_agentstore_config
+            from chroma_agent.action_plugins.settings_management import (
+                _convert_agentstore_config,
+            )
+
             _convert_agentstore_config()
 
-            with open(os.path.join(self.env_path, 'manager-url.conf'),
-                      'r') as f:
-                self.assertEqual(f.read(), "IML_MANAGER_URL={}\n".format(
-                    self.old_server_conf.get('url')))
+            with open(os.path.join(self.env_path, "manager-url.conf"), "r") as f:
+                self.assertEqual(
+                    f.read(),
+                    "IML_MANAGER_URL={}\n".format(self.old_server_conf.get("url")),
+                )
 
             for uuid, old_target_conf in self.old_target_configs.items():
-                self.assertDictEqual(
-                    self.config.get('targets', uuid), old_target_conf)
+                self.assertDictEqual(self.config.get("targets", uuid), old_target_conf)

--- a/tests/test_corosync_config.py
+++ b/tests/test_corosync_config.py
@@ -1,7 +1,10 @@
 import sys
 import mock
 
-from iml_common.test.command_capture_testcase import CommandCaptureTestCase, CommandCaptureCommand
+from iml_common.test.command_capture_testcase import (
+    CommandCaptureTestCase,
+    CommandCaptureCommand,
+)
 from iml_common.lib.firewall_control import FirewallControlEL7
 from iml_common.lib.service_control import ServiceControlEL7
 from iml_common.lib.agent_rpc import agent_result_ok
@@ -28,7 +31,7 @@ class fake_ethtool(object):
         return self.interfaces.keys()
 
     def get_hwaddr(self, name):
-        return self.interfaces[name]['mac_address']
+        return self.interfaces[name]["mac_address"]
 
     def get_flags(self, name):
         # just hard-code this for now
@@ -43,108 +46,141 @@ class TestConfigureCorosync(CommandCaptureTestCase):
         from chroma_agent.lib.corosync import env
 
         def get_ring0():
-            return CorosyncRingInterface('eth0.1.1?1b34*430')
+            return CorosyncRingInterface("eth0.1.1?1b34*430")
 
-        mock.patch('chroma_agent.lib.corosync.get_ring0', get_ring0).start()
+        mock.patch("chroma_agent.lib.corosync.get_ring0", get_ring0).start()
 
         self.interfaces = {
-                'eth0.1.1?1b34*430': {
-                    'device': 'eth0.1.1?1b34*430',
-                    'mac_address': 'de:ad:be:ef:ca:fe',
-                    'ipv4_address': '192.168.1.1',
-                    'ipv4_netmask': '255.255.255.0',
-                    'link_up': True
-                },
-                'eth1': {
-                    'device': 'eth1',
-                    'mac_address': 'ba:db:ee:fb:aa:af',
-                    'ipv4_address': None,
-                    'ipv4_netmask': 0,
-                    'link_up': True
-                }
-            }
+            "eth0.1.1?1b34*430": {
+                "device": "eth0.1.1?1b34*430",
+                "mac_address": "de:ad:be:ef:ca:fe",
+                "ipv4_address": "192.168.1.1",
+                "ipv4_netmask": "255.255.255.0",
+                "link_up": True,
+            },
+            "eth1": {
+                "device": "eth1",
+                "mac_address": "ba:db:ee:fb:aa:af",
+                "ipv4_address": None,
+                "ipv4_netmask": 0,
+                "link_up": True,
+            },
+        }
 
         # Just mock out the entire module ... This will make the tests
         # run on OS X or on Linux without the python-ethtool package.
         self.old_ethtool = sys.modules.get("ethtool", None)
         ethtool = fake_ethtool(self.interfaces)
-        sys.modules['ethtool'] = ethtool
+        sys.modules["ethtool"] = ethtool
 
-        self.write_ifcfg = mock.patch('chroma_agent.lib.node_admin.write_ifcfg').start()
-        self.unmanage_network = mock.patch('chroma_agent.lib.node_admin.unmanage_network').start()
+        self.write_ifcfg = mock.patch("chroma_agent.lib.node_admin.write_ifcfg").start()
+        self.unmanage_network = mock.patch(
+            "chroma_agent.lib.node_admin.unmanage_network"
+        ).start()
 
         self.write_config_to_file = mock.patch(
-            'chroma_agent.action_plugins.manage_corosync.write_config_to_file').start()
+            "chroma_agent.action_plugins.manage_corosync.write_config_to_file"
+        ).start()
 
-        mock.patch('chroma_agent.action_plugins.manage_pacemaker.unconfigure_pacemaker').start()
+        mock.patch(
+            "chroma_agent.action_plugins.manage_pacemaker.unconfigure_pacemaker"
+        ).start()
 
         old_set_address = CorosyncRingInterface.set_address
 
         def set_address(obj, address, prefix):
-            if self.interfaces[obj.name]['ipv4_address'] is None:
-                self.interfaces[obj.name]['ipv4_address'] = address
-                self.interfaces[obj.name]['ipv4_netmask'] = prefix
+            if self.interfaces[obj.name]["ipv4_address"] is None:
+                self.interfaces[obj.name]["ipv4_address"] = address
+                self.interfaces[obj.name]["ipv4_netmask"] = prefix
             old_set_address(obj, address, prefix)
-        mock.patch('chroma_agent.lib.corosync.CorosyncRingInterface.set_address',
-                   set_address).start()
+
+        mock.patch(
+            "chroma_agent.lib.corosync.CorosyncRingInterface.set_address", set_address
+        ).start()
 
         @property
         def has_link(obj):
-            return self.interfaces[obj.name]['link_up']
-        self.link_patcher = mock.patch('chroma_agent.lib.corosync.CorosyncRingInterface.has_link',
-                                       has_link)
+            return self.interfaces[obj.name]["link_up"]
+
+        self.link_patcher = mock.patch(
+            "chroma_agent.lib.corosync.CorosyncRingInterface.has_link", has_link
+        )
         self.link_patcher.start()
 
-        mock.patch('chroma_agent.lib.corosync.find_unused_port', return_value = 4242).start()
+        mock.patch(
+            "chroma_agent.lib.corosync.find_unused_port", return_value=4242
+        ).start()
 
-        mock.patch('chroma_agent.lib.corosync.discover_existing_mcastport').start()
+        mock.patch("chroma_agent.lib.corosync.discover_existing_mcastport").start()
 
-        self.conf_template = env.get_template('corosync.conf')
+        self.conf_template = env.get_template("corosync.conf")
 
         # mock out firewall control calls and check with assert_has_calls in tests
-        self.mock_add_port = mock.patch.object(FirewallControlEL7, '_add_port', return_value=None).start()
-        self.mock_remove_port = mock.patch.object(FirewallControlEL7, '_remove_port', return_value=None).start()
+        self.mock_add_port = mock.patch.object(
+            FirewallControlEL7, "_add_port", return_value=None
+        ).start()
+        self.mock_remove_port = mock.patch.object(
+            FirewallControlEL7, "_remove_port", return_value=None
+        ).start()
 
         # mock out service control objects with ServiceControlEL7 spec and check with assert_has_calls in tests
         # this assumes, quite rightly, that manage_corosync and manage_corosync2 will not both be used in the same test
         self.mock_corosync_service = mock.create_autospec(ServiceControlEL7)
         self.mock_corosync_service.enable.return_value = None
         self.mock_corosync_service.disable.return_value = None
-        mock.patch('chroma_agent.action_plugins.manage_corosync.corosync_service',
-                   self.mock_corosync_service).start()
-        mock.patch('chroma_agent.action_plugins.manage_corosync2.corosync_service',
-                   self.mock_corosync_service).start()
+        mock.patch(
+            "chroma_agent.action_plugins.manage_corosync.corosync_service",
+            self.mock_corosync_service,
+        ).start()
+        mock.patch(
+            "chroma_agent.action_plugins.manage_corosync2.corosync_service",
+            self.mock_corosync_service,
+        ).start()
 
         self.mock_pcsd_service = mock.create_autospec(ServiceControlEL7)
         self.mock_pcsd_service.enable.return_value = None
         self.mock_pcsd_service.start.return_value = None
-        mock.patch('chroma_agent.action_plugins.manage_corosync2.pcsd_service',
-                   self.mock_pcsd_service).start()
+        mock.patch(
+            "chroma_agent.action_plugins.manage_corosync2.pcsd_service",
+            self.mock_pcsd_service,
+        ).start()
 
-        mock.patch('chroma_agent.action_plugins.manage_corosync.firewall_control',
-                   FirewallControlEL7()).start()
-        mock.patch('chroma_agent.action_plugins.manage_corosync2.firewall_control',
-                   FirewallControlEL7()).start()
+        mock.patch(
+            "chroma_agent.action_plugins.manage_corosync.firewall_control",
+            FirewallControlEL7(),
+        ).start()
+        mock.patch(
+            "chroma_agent.action_plugins.manage_corosync2.firewall_control",
+            FirewallControlEL7(),
+        ).start()
 
         # Guaranteed cleanup with unittest2
         self.addCleanup(mock.patch.stopall)
 
     def tearDown(self):
         if self.old_ethtool:
-            sys.modules['ethtool'] = self.old_ethtool
+            sys.modules["ethtool"] = self.old_ethtool
 
     def _ring_iface_info(self, mcast_port):
         from netaddr import IPNetwork
+
         interfaces = []
         for name in sorted(self.interfaces.keys()):
             interface = self.interfaces[name]
-            bindnetaddr = IPNetwork("%s/%s" % (interface['ipv4_address'],
-                                               interface['ipv4_netmask'])).network
+            bindnetaddr = IPNetwork(
+                "%s/%s" % (interface["ipv4_address"], interface["ipv4_netmask"])
+            ).network
             ringnumber = name[-1]
-            interfaces.append(FakeEtherInfo({'ringnumber': ringnumber,
-                                             'bindnetaddr': bindnetaddr,
-                                             'mcastaddr': "226.94.%s.1" % ringnumber,
-                                             'mcastport': mcast_port}))
+            interfaces.append(
+                FakeEtherInfo(
+                    {
+                        "ringnumber": ringnumber,
+                        "bindnetaddr": bindnetaddr,
+                        "mcastaddr": "226.94.%s.1" % ringnumber,
+                        "mcastport": mcast_port,
+                    }
+                )
+            )
         return interfaces
 
     def _render_test_config(self, mcast_port):
@@ -154,37 +190,57 @@ class TestConfigureCorosync(CommandCaptureTestCase):
         from chroma_agent.action_plugins.manage_corosync_common import configure_network
         from chroma_agent.action_plugins.manage_corosync import configure_corosync
 
-        ring0_name = 'eth0.1.1?1b34*430'
-        ring1_name = 'eth1'
-        ring1_ipaddr = '10.42.42.42'
-        ring1_netmask = '255.255.255.0'
+        ring0_name = "eth0.1.1?1b34*430"
+        ring1_name = "eth1"
+        ring1_ipaddr = "10.42.42.42"
+        ring1_netmask = "255.255.255.0"
         old_mcast_port = None
-        new_mcast_port = '4242'
+        new_mcast_port = "4242"
 
         # add shell commands to be expected
-        self.add_commands(CommandCaptureCommand(('/sbin/ip', 'link', 'set', 'dev', ring1_name, 'up')),
-                          CommandCaptureCommand(('/sbin/ip', 'addr', 'add', '%s/%s' % (ring1_ipaddr, ring1_netmask),
-                                                 'dev', ring1_name)))
+        self.add_commands(
+            CommandCaptureCommand(("/sbin/ip", "link", "set", "dev", ring1_name, "up")),
+            CommandCaptureCommand(
+                (
+                    "/sbin/ip",
+                    "addr",
+                    "add",
+                    "%s/%s" % (ring1_ipaddr, ring1_netmask),
+                    "dev",
+                    ring1_name,
+                )
+            ),
+        )
 
         # now a two-step process! first network...
-        self.assertEqual(agent_result_ok,
-                         configure_network(ring0_name,
-                                           ring1_name=ring1_name,
-                                           ring1_ipaddr=ring1_ipaddr,
-                                           ring1_prefix=ring1_netmask))
+        self.assertEqual(
+            agent_result_ok,
+            configure_network(
+                ring0_name,
+                ring1_name=ring1_name,
+                ring1_ipaddr=ring1_ipaddr,
+                ring1_prefix=ring1_netmask,
+            ),
+        )
 
-        self.write_ifcfg.assert_called_with(ring1_name, 'ba:db:ee:fb:aa:af', '10.42.42.42', '255.255.255.0')
-        self.unmanage_network.assert_called_with(ring1_name, 'ba:db:ee:fb:aa:af')
+        self.write_ifcfg.assert_called_with(
+            ring1_name, "ba:db:ee:fb:aa:af", "10.42.42.42", "255.255.255.0"
+        )
+        self.unmanage_network.assert_called_with(ring1_name, "ba:db:ee:fb:aa:af")
 
         # ...then corosync
-        self.assertEqual(agent_result_ok,
-                         configure_corosync(ring0_name, ring1_name, old_mcast_port, new_mcast_port))
+        self.assertEqual(
+            agent_result_ok,
+            configure_corosync(ring0_name, ring1_name, old_mcast_port, new_mcast_port),
+        )
 
         test_config = self._render_test_config(new_mcast_port)
-        self.write_config_to_file.assert_called_with('/etc/corosync/corosync.conf', test_config)
+        self.write_config_to_file.assert_called_with(
+            "/etc/corosync/corosync.conf", test_config
+        )
 
         # check correct firewall and service calls were made
-        self.mock_add_port.assert_has_calls([mock.call(new_mcast_port, 'udp')])
+        self.mock_add_port.assert_has_calls([mock.call(new_mcast_port, "udp")])
         self.mock_remove_port.assert_not_called()
         self.mock_corosync_service.enable.assert_called_once_with()
 
@@ -195,83 +251,135 @@ class TestConfigureCorosync(CommandCaptureTestCase):
         self.mock_corosync_service.reset_mock()
 
         # ...now change corosync mcast port
-        old_mcast_port = '4242'
-        new_mcast_port = '4246'
+        old_mcast_port = "4242"
+        new_mcast_port = "4246"
 
-        self.assertEqual(agent_result_ok,
-                         configure_corosync(ring0_name, ring1_name, old_mcast_port, new_mcast_port))
+        self.assertEqual(
+            agent_result_ok,
+            configure_corosync(ring0_name, ring1_name, old_mcast_port, new_mcast_port),
+        )
 
         test_config = self._render_test_config(new_mcast_port)
         # check we try to write template with new_mcast_port value
-        self.write_config_to_file.assert_called_with('/etc/corosync/corosync.conf', test_config)
+        self.write_config_to_file.assert_called_with(
+            "/etc/corosync/corosync.conf", test_config
+        )
 
         # check correct firewall and service calls were made
-        self.mock_remove_port.assert_has_calls([mock.call(old_mcast_port, 'udp')])
-        self.mock_add_port.assert_has_calls([mock.call(new_mcast_port, 'udp')])
+        self.mock_remove_port.assert_has_calls([mock.call(old_mcast_port, "udp")])
+        self.mock_add_port.assert_has_calls([mock.call(new_mcast_port, "udp")])
         self.mock_corosync_service.enable.assert_called_once_with()
 
     def test_manual_ring1_config_corosync2(self):
-        from chroma_agent.action_plugins.manage_corosync2 import configure_corosync2_stage_1
-        from chroma_agent.action_plugins.manage_corosync2 import configure_corosync2_stage_2
+        from chroma_agent.action_plugins.manage_corosync2 import (
+            configure_corosync2_stage_1,
+        )
+        from chroma_agent.action_plugins.manage_corosync2 import (
+            configure_corosync2_stage_2,
+        )
         from chroma_agent.action_plugins.manage_corosync2 import change_mcast_port
         from chroma_agent.action_plugins.manage_corosync2 import PCS_TCP_PORT
         from chroma_agent.action_plugins.manage_corosync_common import configure_network
 
-        ring0_name = 'eth0.1.1?1b34*430'
-        ring1_name = 'eth1'
-        ring1_ipaddr = '10.42.42.42'
-        ring1_netmask = '255.255.255.0'
-        mcast_port = '4242'
-        new_node_fqdn = 'servera.somewhere.org'
-        pcs_password = 'bondJAMESbond'
+        ring0_name = "eth0.1.1?1b34*430"
+        ring1_name = "eth1"
+        ring1_ipaddr = "10.42.42.42"
+        ring1_netmask = "255.255.255.0"
+        mcast_port = "4242"
+        new_node_fqdn = "servera.somewhere.org"
+        pcs_password = "bondJAMESbond"
 
         # add shell commands to be expected
-        self.add_commands(CommandCaptureCommand(("/sbin/ip", "link", "set", "dev", ring1_name, "up")),
-                          CommandCaptureCommand(("/sbin/ip", "addr", "add", '/'.join([ring1_ipaddr, ring1_netmask]), "dev", ring1_name)),
-                          CommandCaptureCommand(("bash", "-c", "echo bondJAMESbond | passwd --stdin hacluster")),
-                          CommandCaptureCommand(tuple(["pcs", "cluster", "auth"] + [new_node_fqdn] + ["-u", "hacluster", "-p", "bondJAMESbond"])))
+        self.add_commands(
+            CommandCaptureCommand(("/sbin/ip", "link", "set", "dev", ring1_name, "up")),
+            CommandCaptureCommand(
+                (
+                    "/sbin/ip",
+                    "addr",
+                    "add",
+                    "/".join([ring1_ipaddr, ring1_netmask]),
+                    "dev",
+                    ring1_name,
+                )
+            ),
+            CommandCaptureCommand(
+                ("bash", "-c", "echo bondJAMESbond | passwd --stdin hacluster")
+            ),
+            CommandCaptureCommand(
+                tuple(
+                    ["pcs", "cluster", "auth"]
+                    + [new_node_fqdn]
+                    + ["-u", "hacluster", "-p", "bondJAMESbond"]
+                )
+            ),
+        )
 
         # now a two-step process! first network...
-        self.assertEqual(agent_result_ok,
-                         configure_network(ring0_name,
-                                           ring1_name=ring1_name,
-                                           ring1_ipaddr=ring1_ipaddr,
-                                           ring1_prefix=ring1_netmask))
+        self.assertEqual(
+            agent_result_ok,
+            configure_network(
+                ring0_name,
+                ring1_name=ring1_name,
+                ring1_ipaddr=ring1_ipaddr,
+                ring1_prefix=ring1_netmask,
+            ),
+        )
 
-        self.write_ifcfg.assert_called_with(ring1_name, 'ba:db:ee:fb:aa:af', '10.42.42.42',
-                                            '255.255.255.0')
+        self.write_ifcfg.assert_called_with(
+            ring1_name, "ba:db:ee:fb:aa:af", "10.42.42.42", "255.255.255.0"
+        )
 
         # fetch ring info
         r0, r1 = self._ring_iface_info(mcast_port)
 
         # add shell commands to be expected populated with ring interface info
-        self.add_command(("pcs", "cluster", "setup",
-                         "--name", "lustre-ha-cluster",
-                         "--force", new_node_fqdn,
-                         "--transport", "udp",
-                         "--rrpmode", "passive",
-                         "--addr0", str(r0.bindnetaddr),
-                         "--mcast0", str(r0.mcastaddr),
-                         "--mcastport0", str(r0.mcastport),
-                         "--addr1", str(r1.bindnetaddr),
-                         "--mcast1", str(r1.mcastaddr),
-                         "--mcastport1", str(r1.mcastport),
-                         "--token", "17000",
-                         "--fail_recv_const", "10"))
+        self.add_command(
+            (
+                "pcs",
+                "cluster",
+                "setup",
+                "--name",
+                "lustre-ha-cluster",
+                "--force",
+                new_node_fqdn,
+                "--transport",
+                "udp",
+                "--rrpmode",
+                "passive",
+                "--addr0",
+                str(r0.bindnetaddr),
+                "--mcast0",
+                str(r0.mcastaddr),
+                "--mcastport0",
+                str(r0.mcastport),
+                "--addr1",
+                str(r1.bindnetaddr),
+                "--mcast1",
+                str(r1.mcastaddr),
+                "--mcastport1",
+                str(r1.mcastport),
+                "--token",
+                "17000",
+                "--fail_recv_const",
+                "10",
+            )
+        )
 
         # ...then corosync / pcsd
-        self.assertEqual(agent_result_ok,
-                         configure_corosync2_stage_1(mcast_port, pcs_password))
-        self.assertEqual(agent_result_ok,
-                         configure_corosync2_stage_2(ring0_name,
-                                                     ring1_name,
-                                                     new_node_fqdn,
-                                                     mcast_port,
-                                                     pcs_password,
-                                                     True))
+        self.assertEqual(
+            agent_result_ok, configure_corosync2_stage_1(mcast_port, pcs_password)
+        )
+        self.assertEqual(
+            agent_result_ok,
+            configure_corosync2_stage_2(
+                ring0_name, ring1_name, new_node_fqdn, mcast_port, pcs_password, True
+            ),
+        )
 
         # check correct firewall and service calls were made
-        self.mock_add_port.assert_has_calls([mock.call(mcast_port, 'udp'), mock.call(PCS_TCP_PORT, 'tcp')])
+        self.mock_add_port.assert_has_calls(
+            [mock.call(mcast_port, "udp"), mock.call(PCS_TCP_PORT, "tcp")]
+        )
         self.mock_remove_port.assert_not_called()
         self.mock_pcsd_service.start.assert_called_once_with()
         self.mock_corosync_service.enable.assert_called_once_with()
@@ -282,21 +390,26 @@ class TestConfigureCorosync(CommandCaptureTestCase):
         self.mock_corosync_service.reset_mock()
 
         # ...now change corosync mcast port
-        old_mcast_port = '4242'
-        new_mcast_port = '4246'
+        old_mcast_port = "4242"
+        new_mcast_port = "4246"
 
         # add shell command to be expected when updating corosync.conf file with new mcast port value
-        self.add_command(('sed',
-                          '-i.bak',
-                          's/mcastport:.*/mcastport: %s/g' % new_mcast_port,
-                          '/etc/corosync/corosync.conf'))
+        self.add_command(
+            (
+                "sed",
+                "-i.bak",
+                "s/mcastport:.*/mcastport: %s/g" % new_mcast_port,
+                "/etc/corosync/corosync.conf",
+            )
+        )
 
-        self.assertEqual(agent_result_ok,
-                         change_mcast_port(old_mcast_port, new_mcast_port))
+        self.assertEqual(
+            agent_result_ok, change_mcast_port(old_mcast_port, new_mcast_port)
+        )
 
         # check correct firewall and service calls were made
-        self.mock_add_port.assert_has_calls([mock.call(new_mcast_port, 'udp')])
-        self.mock_remove_port.assert_has_calls([mock.call(old_mcast_port, 'udp')])
+        self.mock_add_port.assert_has_calls([mock.call(new_mcast_port, "udp")])
+        self.mock_remove_port.assert_has_calls([mock.call(old_mcast_port, "udp")])
         with self.assertRaises(AssertionError):
             self.mock_corosync_service.enable.assert_any_call()
 
@@ -310,14 +423,19 @@ class TestConfigureCorosync(CommandCaptureTestCase):
         mcast_port = "4242"
 
         # add shell commands to be expected
-        self.add_commands(CommandCaptureCommand(('pcs', 'status', 'nodes', 'corosync')),
-                          CommandCaptureCommand(('pcs', '--force', 'cluster', 'node', 'remove', host_fqdn)))
+        self.add_commands(
+            CommandCaptureCommand(("pcs", "status", "nodes", "corosync")),
+            CommandCaptureCommand(
+                ("pcs", "--force", "cluster", "node", "remove", host_fqdn)
+            ),
+        )
 
-        self.assertEqual(agent_result_ok,
-                         unconfigure_corosync2(host_fqdn, mcast_port))
+        self.assertEqual(agent_result_ok, unconfigure_corosync2(host_fqdn, mcast_port))
 
         self.mock_corosync_service.disable.assert_called_once_with()
-        self.mock_remove_port.assert_has_calls([mock.call(PCS_TCP_PORT, 'tcp'), mock.call(mcast_port, 'udp')])
+        self.mock_remove_port.assert_has_calls(
+            [mock.call(PCS_TCP_PORT, "tcp"), mock.call(mcast_port, "udp")]
+        )
 
         self.assertRanAllCommandsInOrder()
 
@@ -339,8 +457,10 @@ class TestConfigureCorosync(CommandCaptureTestCase):
     def test_failed_has_link(self):
         self.link_patcher.stop()
 
-        mock.patch('chroma_agent.lib.corosync.CorosyncRingInterface.__getattr__',
-                   return_value=False).start()
+        mock.patch(
+            "chroma_agent.lib.corosync.CorosyncRingInterface.__getattr__",
+            return_value=False,
+        ).start()
 
         import errno
 
@@ -348,14 +468,19 @@ class TestConfigureCorosync(CommandCaptureTestCase):
             # EMULTIHOP is what gets raised with IB interfaces
             raise IOError(errno.EMULTIHOP)
 
-        mock.patch('fcntl.ioctl', side_effect=boom).start()
+        mock.patch("fcntl.ioctl", side_effect=boom).start()
 
         from chroma_agent.lib.corosync import get_ring0
+
         iface = get_ring0()
 
         # add shell commands to be expected
-        self.add_commands(CommandCaptureCommand(('/sbin/ip', 'link', 'set', 'dev', iface.name, 'up')),
-                          CommandCaptureCommand(('/sbin/ip', 'link', 'set', 'dev', iface.name, 'down')))
+        self.add_commands(
+            CommandCaptureCommand(("/sbin/ip", "link", "set", "dev", iface.name, "up")),
+            CommandCaptureCommand(
+                ("/sbin/ip", "link", "set", "dev", iface.name, "down")
+            ),
+        )
 
         self.assertFalse(iface.has_link)
 

--- a/tests/test_fail_node.py
+++ b/tests/test_fail_node.py
@@ -1,13 +1,17 @@
-
 from chroma_agent.action_plugins.manage_fail_node import fail_node
-from iml_common.test.command_capture_testcase import CommandCaptureTestCase, CommandCaptureCommand
+from iml_common.test.command_capture_testcase import (
+    CommandCaptureTestCase,
+    CommandCaptureCommand,
+)
 
 
 class TestConfParams(CommandCaptureTestCase):
     def test_failnode(self):
-        self.add_commands(CommandCaptureCommand(("sync",), 0, "", ""),
-                          CommandCaptureCommand(("sync",), 0, "", ""),
-                          CommandCaptureCommand(("init", "0"), 0, "", ""))
+        self.add_commands(
+            CommandCaptureCommand(("sync",), 0, "", ""),
+            CommandCaptureCommand(("sync",), 0, "", ""),
+            CommandCaptureCommand(("init", "0"), 0, "", ""),
+        )
 
         fail_node([])
         self.assertRanAllCommandsInOrder()

--- a/tests/test_fencing.py
+++ b/tests/test_fencing.py
@@ -1,10 +1,13 @@
 import mock
 
 from chroma_agent.lib.pacemaker import PacemakerNode
-from iml_common.test.command_capture_testcase import CommandCaptureTestCase, CommandCaptureCommand
+from iml_common.test.command_capture_testcase import (
+    CommandCaptureTestCase,
+    CommandCaptureCommand,
+)
 
 
-cib_configured_result = '''<cib epoch="99" num_updates="1" admin_epoch="0" validate-with="pacemaker-1.2" cib-last-written="Wed Feb 11 02:41:36 2015" update-origin="lotus-33vm15" update-client="cibadmin" crm_feature_set="3.0.7" have-quorum="1" dc-uuid="lotus-33vm16">
+cib_configured_result = """<cib epoch="99" num_updates="1" admin_epoch="0" validate-with="pacemaker-1.2" cib-last-written="Wed Feb 11 02:41:36 2015" update-origin="lotus-33vm15" update-client="cibadmin" crm_feature_set="3.0.7" have-quorum="1" dc-uuid="lotus-33vm16">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">
@@ -20,46 +23,48 @@ cib_configured_result = '''<cib epoch="99" num_updates="1" admin_epoch="0" valid
       </cluster_property_set>
     </crm_config>
   </configuration>
-</cib>'''
+</cib>"""
 
 
 class FencingTestCase(CommandCaptureTestCase):
-
     def setUp(self):
         super(FencingTestCase, self).setUp()
 
-        self.fake_node_hostname = 'fake.host.domain'
-        self.fake_node_uuid = '1234567890'
+        self.fake_node_hostname = "fake.host.domain"
+        self.fake_node_uuid = "1234567890"
         self.fake_node_attributes = {}
 
         self.stdin_lines = None
 
         def fake_hostname():
             return self.fake_node_hostname
-        patcher = mock.patch('socket.gethostname', fake_hostname)
+
+        patcher = mock.patch("socket.gethostname", fake_hostname)
         patcher.start()
 
         @property
         def nodes(obj):
-            pacemaker_node = PacemakerNode(self.fake_node_hostname,
-                                           self.fake_node_uuid)
+            pacemaker_node = PacemakerNode(self.fake_node_hostname, self.fake_node_uuid)
             pacemaker_node.attributes = self.fake_node_attributes
             return [pacemaker_node]
 
-        patcher = mock.patch('chroma_agent.lib.pacemaker.PacemakerConfig.nodes', nodes)
+        patcher = mock.patch("chroma_agent.lib.pacemaker.PacemakerConfig.nodes", nodes)
         patcher.start()
 
         import chroma_agent.fence_chroma
+
         real_stdin_to_args = chroma_agent.fence_chroma.stdin_to_args
 
         def stdin_to_args(**kwargs):
             return real_stdin_to_args(self.stdin_lines)
-        patcher = mock.patch('chroma_agent.fence_chroma.stdin_to_args', stdin_to_args)
+
+        patcher = mock.patch("chroma_agent.fence_chroma.stdin_to_args", stdin_to_args)
         patcher.start()
 
         # nose confuses things
         import sys
-        sys.argv = ['fence_chroma']
+
+        sys.argv = ["fence_chroma"]
 
         # Guaranteed cleanup with unittest2
         self.addCleanup(mock.patch.stopall)
@@ -69,11 +74,14 @@ class TestAgentConfiguration(FencingTestCase):
     def setUp(self):
         super(TestAgentConfiguration, self).setUp()
         from chroma_agent.action_plugins import manage_corosync
-        self.add_command(('cibadmin', '--query', '--local'))
 
-        self.fake_node_attributes = {'0_fence_agent': 'fake_agent',
-                                     '0_fence_login': 'admin',
-                                     '0_fence_password': 'yourmom'}
+        self.add_command(("cibadmin", "--query", "--local"))
+
+        self.fake_node_attributes = {
+            "0_fence_agent": "fake_agent",
+            "0_fence_login": "admin",
+            "0_fence_password": "yourmom",
+        }
 
         # Reset the corosync configured flags
         manage_corosync.pacemaker_configured = False
@@ -81,27 +89,73 @@ class TestAgentConfiguration(FencingTestCase):
     def test_multi_agent_config(self):
         from chroma_agent.action_plugins.manage_pacemaker import configure_fencing
 
-        agents = [{'agent': 'fence_virsh',
-                   'ipaddr': '1.2.3.4',
-                   'ipport': '22',
-                   'login': 'monkey',
-                   'password': 'banana',
-                   'plug': 'monkey_vm'},
-                  {'agent': 'fence_apc',
-                   'ipaddr': '4.3.2.1',
-                   'ipport': '23',
-                   'login': 'apc',
-                   'password': 'apc',
-                   'plug': '1'}]
+        agents = [
+            {
+                "agent": "fence_virsh",
+                "ipaddr": "1.2.3.4",
+                "ipport": "22",
+                "login": "monkey",
+                "password": "banana",
+                "plug": "monkey_vm",
+            },
+            {
+                "agent": "fence_apc",
+                "ipaddr": "4.3.2.1",
+                "ipport": "23",
+                "login": "apc",
+                "password": "apc",
+                "plug": "1",
+            },
+        ]
 
-        for field in ['agent', 'password', 'login']:
-            self.add_command(('crm_attribute', '-D', '-t', 'nodes', '-U', self.fake_node_hostname, '-n', '0_fence_%s' % field))
+        for field in ["agent", "password", "login"]:
+            self.add_command(
+                (
+                    "crm_attribute",
+                    "-D",
+                    "-t",
+                    "nodes",
+                    "-U",
+                    self.fake_node_hostname,
+                    "-n",
+                    "0_fence_%s" % field,
+                )
+            )
 
         for i, agent in enumerate(agents):
-            for key in ['ipport', 'plug', 'ipaddr', 'login', 'password', 'agent']:  # The fields are the order the comamnds should occur in
-                self.add_command(('crm_attribute', '-t', 'nodes', '-U', self.fake_node_hostname, '-n', '%d_fence_%s' % (i, key), '-v', agent[key]))
+            for key in [
+                "ipport",
+                "plug",
+                "ipaddr",
+                "login",
+                "password",
+                "agent",
+            ]:  # The fields are the order the comamnds should occur in
+                self.add_command(
+                    (
+                        "crm_attribute",
+                        "-t",
+                        "nodes",
+                        "-U",
+                        self.fake_node_hostname,
+                        "-n",
+                        "%d_fence_%s" % (i, key),
+                        "-v",
+                        agent[key],
+                    )
+                )
 
-        self.add_command(('cibadmin', '--modify', '--allow-create', '-o', 'crm_config', '-X', '<cluster_property_set id="cib-bootstrap-options">\n<nvpair id="cib-bootstrap-options-stonith-enabled" name="stonith-enabled" value="true"/>\n'))
+        self.add_command(
+            (
+                "cibadmin",
+                "--modify",
+                "--allow-create",
+                "-o",
+                "crm_config",
+                "-X",
+                '<cluster_property_set id="cib-bootstrap-options">\n<nvpair id="cib-bootstrap-options-stonith-enabled" name="stonith-enabled" value="true"/>\n',
+            )
+        )
 
         configure_fencing(agents)
 
@@ -110,14 +164,38 @@ class TestAgentConfiguration(FencingTestCase):
 
     def test_node_standby(self):
         from chroma_agent.action_plugins.manage_pacemaker import set_node_standby
-        self.add_command(('crm_attribute', '-N', self.fake_node_hostname, '-n', 'standby', '-v', 'on', '--lifetime=forever'))
+
+        self.add_command(
+            (
+                "crm_attribute",
+                "-N",
+                self.fake_node_hostname,
+                "-n",
+                "standby",
+                "-v",
+                "on",
+                "--lifetime=forever",
+            )
+        )
         set_node_standby(self.fake_node_hostname)
 
         self.assertRanAllCommands()
 
     def test_node_online(self):
         from chroma_agent.action_plugins.manage_pacemaker import set_node_online
-        self.add_command(('crm_attribute', '-N', self.fake_node_hostname, '-n', 'standby', '-v', 'off', '--lifetime=forever'))
+
+        self.add_command(
+            (
+                "crm_attribute",
+                "-N",
+                self.fake_node_hostname,
+                "-n",
+                "standby",
+                "-v",
+                "off",
+                "--lifetime=forever",
+            )
+        )
 
         set_node_online(self.fake_node_hostname)
 
@@ -128,26 +206,34 @@ class TestFenceAgent(FencingTestCase):
     def setUp(self):
         super(TestFenceAgent, self).setUp()
 
-        self.fake_node_attributes = {'0_fence_agent': 'fence_apc',
-                                     '0_fence_login': 'admin',
-                                     '0_fence_password': 'yourmom',
-                                     '0_fence_ipaddr': '1.2.3.4',
-                                     '0_fence_plug': '1'}
+        self.fake_node_attributes = {
+            "0_fence_agent": "fence_apc",
+            "0_fence_login": "admin",
+            "0_fence_password": "yourmom",
+            "0_fence_ipaddr": "1.2.3.4",
+            "0_fence_plug": "1",
+        }
 
-        call_template = "%(0_fence_agent)s -a %(0_fence_ipaddr)s -u 23 -l %(0_fence_login)s -p %(0_fence_password)s -n %(0_fence_plug)s" % self.fake_node_attributes
+        call_template = (
+            "%(0_fence_agent)s -a %(0_fence_ipaddr)s -u 23 -l %(0_fence_login)s -p %(0_fence_password)s -n %(0_fence_plug)s"
+            % self.fake_node_attributes
+        )
         call_base = tuple(call_template.split())
 
-        self.add_commands(CommandCaptureCommand(('cibadmin', '--query', '--local')),
-                          CommandCaptureCommand((call_base + ('-o', 'off'))),
-                          CommandCaptureCommand((call_base + ('-o', 'on'))))
+        self.add_commands(
+            CommandCaptureCommand(("cibadmin", "--query", "--local")),
+            CommandCaptureCommand((call_base + ("-o", "off"))),
+            CommandCaptureCommand((call_base + ("-o", "on"))),
+        )
 
     def test_finding_fenceable_nodes(self):
         self.reset_command_capture()
-        self.add_command(('cibadmin', '--query', '--local'))
+        self.add_command(("cibadmin", "--query", "--local"))
 
         # Not strictly an agent test, but the tested method is used by
         # the agent to generate the -o list output.
         from chroma_agent.lib.pacemaker import PacemakerConfig
+
         p_cfg = PacemakerConfig()
         self.assertEqual(len(p_cfg.fenceable_nodes), 1)
 
@@ -157,16 +243,18 @@ class TestFenceAgent(FencingTestCase):
         from chroma_agent.fence_chroma import main as agent_main
 
         # Normal use, stonithd feeds commands via stdin
-        self.stdin_lines = ["nodename=%s" % self.fake_node_hostname,
-                            "action=reboot",
-                            "port=%s" % self.fake_node_hostname]
+        self.stdin_lines = [
+            "nodename=%s" % self.fake_node_hostname,
+            "action=reboot",
+            "port=%s" % self.fake_node_hostname,
+        ]
         agent_main()
         self.assertRanAllCommands()
 
         self.reset_command_capture_logs()
 
         # Command-line should work too
-        agent_main(['-o', 'reboot', '-n', self.fake_node_hostname])
+        agent_main(["-o", "reboot", "-n", self.fake_node_hostname])
         self.assertRanAllCommands()
 
     def test_fence_agent_on_off(self):
@@ -174,44 +262,43 @@ class TestFenceAgent(FencingTestCase):
 
         # These options aren't likely to be used for STONITH, but they
         # should still work for manual invocation.
-        agent_main(['-o', 'off', '-n', self.fake_node_hostname])
-        agent_main(['-o', 'on', '-n', self.fake_node_hostname])
+        agent_main(["-o", "off", "-n", self.fake_node_hostname])
+        agent_main(["-o", "on", "-n", self.fake_node_hostname])
 
         self.assertRanAllCommands()
 
     def test_fence_agent_monitor(self):
-        patcher = mock.patch('sys.exit')
+        patcher = mock.patch("sys.exit")
         exit = patcher.start()
 
         # Kind of a silly test, but we just want to make sure that our
         # agent's monitor option doesn't barf.
         from chroma_agent.fence_chroma import main as agent_main
-        agent_main(['-o', 'monitor'])
+
+        agent_main(["-o", "monitor"])
         exit.assert_called_with(0)
 
         # Make sure running with args from stdin works...
-        self.stdin_lines = ["nodename=%s" % self.fake_node_hostname,
-                            "action=monitor"]
+        self.stdin_lines = ["nodename=%s" % self.fake_node_hostname, "action=monitor"]
         agent_main()
         exit.assert_called_with(0)
 
         # Apparently stonithd sometimes(?) uses option instead of action...
-        self.stdin_lines = ["nodename=%s" % self.fake_node_hostname,
-                            "option=monitor"]
+        self.stdin_lines = ["nodename=%s" % self.fake_node_hostname, "option=monitor"]
         agent_main()
         exit.assert_called_with(0)
 
     def test_standby_node_not_fenced(self):
         self.reset_command_capture()
-        self.add_command(('cibadmin', '--query', '--local'))
+        self.add_command(("cibadmin", "--query", "--local"))
 
         # a node in standby should not be fenced
         self.fake_node_attributes = self.fake_node_attributes.copy()
-        self.fake_node_attributes['standby'] = "on"
+        self.fake_node_attributes["standby"] = "on"
 
         from chroma_agent.fence_chroma import main as agent_main
 
-        agent_args = ('-o', 'off', '-n', self.fake_node_hostname)
+        agent_args = ("-o", "off", "-n", self.fake_node_hostname)
         agent_main(agent_args)
 
         self.assertRanAllCommandsInOrder()

--- a/tests/test_node_admin.py
+++ b/tests/test_node_admin.py
@@ -2,56 +2,84 @@ import errno
 import mock
 from chroma_agent.lib import node_admin
 from chroma_agent.lib.shell import AgentShell
-from iml_common.test.command_capture_testcase import CommandCaptureTestCase, CommandCaptureCommand
+from iml_common.test.command_capture_testcase import (
+    CommandCaptureTestCase,
+    CommandCaptureCommand,
+)
 
 
 class TestNodeAdmin(CommandCaptureTestCase):
     def setUp(self):
         super(TestNodeAdmin, self).setUp()
 
-        self.write_ifcfg_result = 'bobs.your.uncle'
-        self.device_name = 'the device'
-        self.mac_address = 'its mac address'
+        self.write_ifcfg_result = "bobs.your.uncle"
+        self.device_name = "the device"
+        self.mac_address = "its mac address"
 
-        self.write_ifcfg_mock = mock.patch('chroma_agent.lib.node_admin.write_ifcfg',
-                                           return_value=self.write_ifcfg_result).start()
+        self.write_ifcfg_mock = mock.patch(
+            "chroma_agent.lib.node_admin.write_ifcfg",
+            return_value=self.write_ifcfg_result,
+        ).start()
 
     def test_unmanage_network_nm_running(self):
-        self.add_commands(CommandCaptureCommand(('nmcli', 'con', 'load', self.write_ifcfg_result)))
+        self.add_commands(
+            CommandCaptureCommand(("nmcli", "con", "load", self.write_ifcfg_result))
+        )
 
         node_admin.unmanage_network(self.device_name, self.mac_address)
 
         self.assertRanAllCommandsInOrder()
-        self.write_ifcfg_mock.assert_called_with(self.device_name, self.mac_address, None, None)
+        self.write_ifcfg_mock.assert_called_with(
+            self.device_name, self.mac_address, None, None
+        )
 
     def test_unmanage_network_nm_permission_denied(self):
         noent_exception = OSError()
         noent_exception.errno = errno.EACCES
 
-        with mock.patch('chroma_agent.lib.shell.AgentShell.try_run', side_effect=noent_exception):
+        with mock.patch(
+            "chroma_agent.lib.shell.AgentShell.try_run", side_effect=noent_exception
+        ):
             with self.assertRaises(OSError):
-                self.assertIsNone(node_admin.unmanage_network(self.device_name, self.mac_address))
+                self.assertIsNone(
+                    node_admin.unmanage_network(self.device_name, self.mac_address)
+                )
 
     def test_unmanage_network_nm_not_installed(self):
         noent_exception = OSError()
         noent_exception.errno = errno.ENOENT
 
-        with mock.patch('chroma_agent.lib.shell.AgentShell.try_run', side_effect=noent_exception):
-            self.assertIsNone(node_admin.unmanage_network(self.device_name, self.mac_address))
+        with mock.patch(
+            "chroma_agent.lib.shell.AgentShell.try_run", side_effect=noent_exception
+        ):
+            self.assertIsNone(
+                node_admin.unmanage_network(self.device_name, self.mac_address)
+            )
 
     def test_unmanage_network_nm_known_failures(self):
         for expected_rc in [node_admin.NM_STOPPED_RC]:
             self.reset_command_capture()
-            self.add_commands(CommandCaptureCommand(('nmcli', 'con', 'load', self.write_ifcfg_result), rc=expected_rc))
+            self.add_commands(
+                CommandCaptureCommand(
+                    ("nmcli", "con", "load", self.write_ifcfg_result), rc=expected_rc
+                )
+            )
 
             node_admin.unmanage_network(self.device_name, self.mac_address)
 
             self.assertRanAllCommandsInOrder()
 
     def test_unmanage_network_nm_unknown_failures(self):
-        for expected_rc in [2, 127]:  # Network Manager bad syntax and command unavailable return codes
+        for expected_rc in [
+            2,
+            127,
+        ]:  # Network Manager bad syntax and command unavailable return codes
             self.reset_command_capture()
-            self.add_commands(CommandCaptureCommand(('nmcli', 'con', 'load', self.write_ifcfg_result), rc=expected_rc))
+            self.add_commands(
+                CommandCaptureCommand(
+                    ("nmcli", "con", "load", self.write_ifcfg_result), rc=expected_rc
+                )
+            )
 
             with self.assertRaises(AgentShell.CommandExecutionError):
                 node_admin.unmanage_network(self.device_name, self.mac_address)

--- a/tests/test_shutdown_reboot.py
+++ b/tests/test_shutdown_reboot.py
@@ -6,27 +6,27 @@ from iml_common.test.command_capture_testcase import CommandCaptureTestCase
 
 
 class TestServerShutdownAndReboot(CommandCaptureTestCase):
-    @patch('os._exit')
+    @patch("os._exit")
     def test_server_shutdown(self, os__exit):
-        run_args = ('shutdown', '-H', 'now')
+        run_args = ("shutdown", "-H", "now")
         self.add_command(run_args)
 
         try:
             shutdown_server()
-        except CallbackAfterResponse, e:
+        except CallbackAfterResponse as e:
             e.callback()
         self.assertRanAllCommandsInOrder()
 
         self.assertTrue(os__exit.called)
 
-    @patch('os._exit')
+    @patch("os._exit")
     def test_server_reboot(self, os__exit):
-        run_args = ('shutdown', '-r', 'now')
+        run_args = ("shutdown", "-r", "now")
         self.add_command(run_args)
 
         try:
             reboot_server()
-        except CallbackAfterResponse, e:
+        except CallbackAfterResponse as e:
             e.callback()
         self.assertRanAllCommandsInOrder()
         self.assertTrue(os__exit.called)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,9 +7,11 @@ class PatchedContextTestCase(unittest.TestCase):
         super(PatchedContextTestCase, self).__init__(methodName)
         self._test_root = None
 
-        empty_map = {'blockDevices': {}, 'zed': {}, 'localMounts': []}
-        mock.patch('chroma_agent.device_plugins.block_devices.scanner_cmd',
-                   return_value=empty_map).start()
+        empty_map = {"blockDevices": {}, "zed": {}, "localMounts": []}
+        mock.patch(
+            "chroma_agent.device_plugins.block_devices.scanner_cmd",
+            return_value=empty_map,
+        ).start()
 
     def _find_subclasses(self, klass):
         """Introspectively find all descendents of a class"""
@@ -30,11 +32,13 @@ class PatchedContextTestCase(unittest.TestCase):
         self._test_root = value
 
         from chroma_agent.device_plugins.audit import BaseAudit
+
         for subclass in self._find_subclasses(BaseAudit):
-            mock.patch.object(subclass, 'fscontext', self._test_root).start()
+            mock.patch.object(subclass, "fscontext", self._test_root).start()
 
         # These classes aren't reliably detected for patching.
         from chroma_agent.device_plugins.audit.node import NodeAudit
-        mock.patch.object(NodeAudit, 'fscontext', self._test_root).start()
+
+        mock.patch.object(NodeAudit, "fscontext", self._test_root).start()
 
         self.addCleanup(mock.patch.stopall)


### PR DESCRIPTION
Use [black](https://github.com/ambv/black)
to reformat the entire iml-agent repo.

Black is an autoformatter similar to gofmt, rustfmt, prettier et. all.

The caveat is black only runs on Python 3, but the upshot is it parses
Python 3 syntax, so after this change all the code in this repo is
parsable by Python 3.

Also add a travis step to check for consistent formatting in every
commit.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>