### PR TITLE
Sort target_devices in detect_scan command

### DIFF
--- a/chroma_agent/action_plugins/detect_scan.py
+++ b/chroma_agent/action_plugins/detect_scan.py
@@ -31,7 +31,7 @@ class LocalTargets(object):
         # when we see a combined MGS+MDT
         uuid_name_to_target = {}
 
-        for device in target_devices:
+        for device in sorted(target_devices, cmp=LocalTargets.comparator):
             block_device = BlockDevice(device["type"], device["path"])
 
             # If the target_device has no uuid then it doesn't have a filesystem and is of no use to use, but
@@ -79,6 +79,18 @@ class LocalTargets(object):
                     uuid_name_to_target[(device["uuid"], name)] = target_dict
 
         self.targets = uuid_name_to_target.values()
+
+    @classmethod
+    def comparator(cls, a, b):
+        value = cmp(a["type"], b["type"])
+
+        if value == 0:
+            value = cmp(a["uuid"], b["uuid"])
+
+        if value == 0:
+            value = cmp(a["path"], b["path"])
+
+        return value
 
 
 class MgsTargets(object):


### PR DESCRIPTION
I noticed that `detect_scan` agent command, associated with functionality of filesystem detection operates incoming devices in a random order.

That's especially bad for the case when you have more than one instance of the same device in the system and they are not well associated with each other. Thus, scanner might mix up different types of block devices which is not preferable behavior.

For example, if you have `scst_local` target devices among with classic block devices, the scanner gives more or less random result each time.

So, since an order is a subset of disorder, I see no harm in this change.

I guessed order by `__init__()` content, so feel free to comment on it.