### PR TITLE
Use cibadmin to add/remove resources

### DIFF
--- a/chroma_agent/action_plugins/manage_targets.py
+++ b/chroma_agent/action_plugins/manage_targets.py
@@ -454,6 +454,12 @@ def _configure_target_ha(ha_label, info, enabled=False):
     else:
         extra = ["--disabled"]
 
+    # FIXME: This is a hack for ocf:lustre:Lustre up to Lustre 2.10.7/2.12 see LU-11461
+    if info["device_type"] == "ldiskfs":
+        result = AgentShell.run(["realpath", info["bdev"]])
+        if result.rc == 0 and result.stdout.startswith("/dev/sd"):
+            info["bdev"] = result.stdout.strip()
+
     res = _resource_xml(
         ha_label,
         "ocf:lustre:Lustre",

--- a/chroma_agent/lib/pacemaker.py
+++ b/chroma_agent/lib/pacemaker.py
@@ -317,7 +317,18 @@ class PacemakerConfig(object):
         return result
 
 
-def cibadmin(command_args, timeout=120):
+def cibxpath(command, xpath, extra=[]):
+    """
+    command: query, delete, delete-all, etc...
+    """
+    return _cibadmin(["--{}".format(command), "--xpath", xpath] + extra)
+
+
+def cibcreate(scope, xml, extra=[]):
+    return _cibadmin(["--create", "--scope", scope, "--xml-text", xml] + extra)
+
+
+def _cibadmin(command_args, timeout=120, raise_on_timeout=False):
     assert timeout > 0, "timeout must be greater than zero"
 
     # I think these are "errno" values, but I'm not positive
@@ -342,13 +353,22 @@ def cibadmin(command_args, timeout=120):
         elif result.rc not in RETRY_CODES:
             break
 
-    if result.rc in RETRY_CODES:
+    if raise_on_timeout and result.rc in RETRY_CODES:
         raise PacemakerError(
             "%s timed out after %d seconds: rc: %s, stderr: %s"
             % (" ".join(command_args), timeout, result.rc, result.stderr)
         )
-    else:
+
+    return result
+
+
+def cibadmin(command_args, timeout):
+    result = _cibadmin(command_args, timeout, True)
+
+    if result.rc != 0:
         raise AgentShell.CommandExecutionError(result, command_args)
+
+    return result
 
 
 def pacemaker_running():


### PR DESCRIPTION
This should address all the failed testing that seems to be cause by pcsd raciness.

Convert minidom to ElementTree
Use cibadmin to avoid seeming race conditions within pcsd.
Allows ZFS+Lustre group to be added and removed as single action.
