### PR TITLE
Allow easier rpm building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ chroma_agent.egg-info/
 _topdir/
 tags
 settings.json
+*.rpm

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,11 @@ include LICENSE.txt
 include Target
 include ZFS
 include logrotate.cfg
+include chroma-agent.service
+include 50-chroma-agent.preset
+include iml-storage-server.target
+include 10-device-scanner.target.conf
+include python-iml-agent.spec
 include chroma_agent/templates/corosync.conf
 include chroma_agent/templates/ifcfg-nic
 include chroma_agent/templates/chroma-copytool

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+rpms::
+	rm -rf _topdir *.rpm
+	mkdir -p _topdir/SOURCES/
+	python setup.py sdist -d _topdir/SOURCES/
+	rpmbuild -ba -D "%_topdir ${PWD}/_topdir" python-iml-agent.spec
+	cp -l _topdir/RPMS/*/*.rpm ./
+
+repo:: rpms
+	(cd _topdir/RPMS; createrepo .)
+
+clean::
+	python setup.py clean
+	rm -f *~
+
+extraclean:: clean
+	python setup.py clean --all
+	rm -rf _topdir/ dist/
+	rm -f *.rpm

--- a/python-iml-agent.spec
+++ b/python-iml-agent.spec
@@ -20,11 +20,6 @@ Summary:        IML Agent
 License:        MIT
 URL:            https://pypi.python.org/pypi/%{pypi_name}
 Source0:        %{source}
-Source1:        %{unit_name}
-Source2:        50-chroma-agent.preset
-Source3:        logrotate.cfg
-Source4:        iml-storage-server.target
-Source5:        10-device-scanner.target.conf
 Group:          Development/Libraries
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 Prefix:         %{_prefix}
@@ -103,15 +98,15 @@ rm -rf %{buildroot}
 mkdir -p $RPM_BUILD_ROOT/usr/sbin/
 mv $RPM_BUILD_ROOT/usr/{,s}bin/fence_chroma
 mv $RPM_BUILD_ROOT/usr/{,s}bin/chroma-copytool-monitor
-mkdir -p %{buildroot}%{_unitdir}/
-mkdir -p %{buildroot}%{_presetdir}
-install -m 644 %{SOURCE1} %{buildroot}%{_unitdir}/
-install -m 644 %{SOURCE2} %{buildroot}%{_presetdir}/
-mkdir -p $RPM_BUILD_ROOT/etc/{init,logrotate}.d/
-install -m 644 %{SOURCE3} $RPM_BUILD_ROOT/etc/logrotate.d/chroma-agent
-install -m 644 %{SOURCE4} %{buildroot}%{_unitdir}/iml-storage-server.target
 mkdir -p %{buildroot}%{_unitdir}/device-scanner.target.d/
-install -m 644 %{SOURCE5} %{buildroot}%{_unitdir}/device-scanner.target.d/10-device-scanner.target.conf
+install -m 644 %{unit_name} %{buildroot}%{_unitdir}/
+install -m 644 iml-storage-server.target %{buildroot}%{_unitdir}/iml-storage-server.target
+install -m 644 10-device-scanner.target.conf %{buildroot}%{_unitdir}/device-scanner.target.d/10-device-scanner.target.conf
+mkdir -p %{buildroot}%{_presetdir}
+install -m 644 50-chroma-agent.preset %{buildroot}%{_presetdir}/
+mkdir -p $RPM_BUILD_ROOT/etc/{init,logrotate}.d/
+install -m 644 logrotate.cfg $RPM_BUILD_ROOT/etc/logrotate.d/chroma-agent
+mkdir -p %{buildroot}%{_unitdir}/device-scanner.target.d/
 
 touch management.files
 cat <<EndOfList>>management.files


### PR DESCRIPTION
Package all neccissary sources in package build with setup.py sdist, to build rpm.
Allow rpmbuild -ta iml-agent-$VERSION.tar.gz
Add Makefile to allow "make rpms" to work

Signed-off-by: Nathaniel Clark <nclark@whamcloud.com>