### PR TITLE
Ensure that journald message is always valid unicode

### DIFF
--- a/chroma_agent/device_plugins/systemd_journal.py
+++ b/chroma_agent/device_plugins/systemd_journal.py
@@ -22,6 +22,10 @@ _queue = Queue.Queue()
 
 
 MAX_LOG_LINES_PER_MESSAGE = 64
+CONVERTERS = {
+    # Ensure that message field is always valid unicode
+    "MESSAGE": lambda message: message.decode("unicode_escape")
+}
 
 
 def parse_journal(data):
@@ -56,7 +60,7 @@ class SystemdJournalListener(threading.Thread):
         self.should_run = True
 
     def run(self):
-        j = systemd.journal.Reader()
+        j = systemd.journal.Reader(converters=CONVERTERS)
         j.seek_tail()
         while self.should_run:
             if j.wait(1) == systemd.journal.APPEND:


### PR DESCRIPTION
This `PR` fixes another issue, associated with the way your software handles results of plugin execution.
I've got this error intially:
```
[08/Jan/2019:20:12:56] daemon ERROR Unhandled error in thread HttpWriter: Traceback (most recent call last): 
 File "/usr/lib/python2.7/site-packages/chroma_agent/agent_client.py", line 329, in run 
 self._run() File "/usr/lib/python2.7/site-packages/chroma_agent/agent_client.py", line 385, in _run 
 self.send() File "/usr/lib/python2.7/site-packages/chroma_agent/agent_client.py", line 424, in send 
 message_length = len(json.dumps(message.dump(self._client._fqdn))) 
 File "/usr/lib64/python2.7/json/__init__.py", line 243, in dumps 
 return _default_encoder.encode(obj) File "/usr/lib64/python2.7/json/encoder.py", line 207, in encode 
 chunks = self.iterencode(o, _one_shot=True) 
 File "/usr/lib64/python2.7/json/encoder.py", line 270, in iterencode return _iterencode(o, 0) 
 UnicodeDecodeError: 'utf8' codec can't decode byte 0xff in position 2561: invalid start byte 
```
Which lead me to this line: https://github.com/whamcloud/iml-agent/blob/1b55141645578f554abe3167fb6bea1b52120056/chroma_agent/agent_client.py#L424
As python docs suggest, `json.dumps` has parameter `ensure_ascii` which by default has value `True`.
Behavior when input value has type `str` instead of `unicode` is not well defined but the module definitely tries to decode it as `utf-8`, which it might not be an here's why:

Plugin `systemd_journal` puts `MESSAGE` field written by `systemd.journal.Reader` object 

https://github.com/whamcloud/iml-agent/blob/1b55141645578f554abe3167fb6bea1b52120056/chroma_agent/device_plugins/systemd_journal.py#L49

Official documentation on module `systemd.journal` module suggests that fields are mapped into Python types by `converters` from `bytes`. https://www.freedesktop.org/software/systemd/python-systemd/journal.html#systemd.journal.Reader.__init__

And if there's no such converter, it tries to convert it into Unicode string **but leaves it as is if conversion fails.**
As we can see, by default, there's no converter for the `MESSAGE` field, so it falls back into default behavior. https://github.com/systemd/python-systemd/blob/master/systemd/journal.py#L74

Thus, `json.dumps` receives either `str` or `unicode`.
Simple case to reproduce the behavior in `Python 2`:
```
import json
x = b'\xff'
json.dumps(x.decode('unicode_escape'))
json.dumps(x)
```

```
>>> import json
>>> x = b'\xff'
>>> json.dumps(x.decode('unicode_escape'))
'"\\u00ff"'
>>> json.dumps(x)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib64/python2.7/json/__init__.py", line 243, in dumps
    return _default_encoder.encode(obj)
  File "/usr/lib64/python2.7/json/encoder.py", line 201, in encode
    return encode_basestring_ascii(o)
UnicodeDecodeError: 'utf8' codec can't decode byte 0xff in position 0: invalid start byte
```

You might want to write a test for this in future but I just want this bug to be fixed in upstream.

@jgrund @utopiabound would you kindly review this `PR` too, please?