### PR TITLE
Use None as a temporary way to make it further in SSI testing.

### DIFF
--- a/chroma_agent/action_plugins/manage_targets.py
+++ b/chroma_agent/action_plugins/manage_targets.py
@@ -24,8 +24,6 @@ from iml_common.lib.agent_rpc import agent_result_ok
 from iml_common.lib.agent_rpc import agent_ok_or_error
 from iml_common.lib.agent_rpc import agent_result_is_error
 from iml_common.lib.agent_rpc import agent_result_is_ok
-from iml_common.lib.exception_sandbox import exceptionSandBox
-
 
 def writeconf_target(
     device=None,
@@ -141,7 +139,6 @@ def _get_resource_locations(xml):
     return locations
 
 
-@exceptionSandBox(console_log, None)
 def get_resource_locations():
     """Parse `crm_mon -1` to identify where (if anywhere) resources
     (i.e. targets) are running

--- a/chroma_agent/action_plugins/manage_targets.py
+++ b/chroma_agent/action_plugins/manage_targets.py
@@ -442,19 +442,22 @@ def _nvpair_xml(element, key, value):
     )
 
 
-def _resource_xml(label, ra, nvpair={}, ops={}):
+def _resource_xml(label, ra, nvpair=None, ops=None):
     ras = ra.split(":")
     res = ET.Element(
         "primitive", {"id": label, "class": ras[0], "provider": ras[1], "type": ras[2]}
     )
-    attr = ET.SubElement(
-        res, "instance_attributes", {"id": "{}-instance_attributes".format(label)}
-    )
-    for key in nvpair:
-        _nvpair_xml(attr, key, nvpair[key])
+    if nvpair:
+        attr = ET.SubElement(
+            res, "instance_attributes", {"id": "{}-instance_attributes".format(label)}
+        )
+        for key in nvpair:
+            _nvpair_xml(attr, key, nvpair[key])
 
     result = AgentShell.try_run(["crm_resource", "--show-metadata={}".format(ra)])
     agent = ET.fromstring(result)
+    if ops is None:
+        ops = {}
 
     attr = ET.SubElement(res, "operations")
     for key in ["start", "stop", "monitor"]:
@@ -473,7 +476,7 @@ def _resource_xml(label, ra, nvpair={}, ops={}):
                 "id": "{}-{}-interval-{}".format(label, key, ops[key]["interval"]),
                 "interval": ops[key]["interval"],
                 "timeout": ops[key]["timeout"],
-            }
+            },
         )
     return res
 

--- a/chroma_agent/action_plugins/manage_targets.py
+++ b/chroma_agent/action_plugins/manage_targets.py
@@ -150,6 +150,8 @@ def get_resource_locations():
         # ENOENT is fine here.  Pacemaker might not be installed yet.
         if err.errno != errno.ENOENT:
             raise err
+        else:
+            return None
 
     if result.rc != 0:
         # Pacemaker not running, or no resources configured yet

--- a/chroma_agent/action_plugins/manage_targets.py
+++ b/chroma_agent/action_plugins/manage_targets.py
@@ -25,6 +25,7 @@ from iml_common.lib.agent_rpc import agent_ok_or_error
 from iml_common.lib.agent_rpc import agent_result_is_error
 from iml_common.lib.agent_rpc import agent_result_is_ok
 
+
 def writeconf_target(
     device=None,
     target_types=(),

--- a/chroma_agent/action_plugins/manage_targets.py
+++ b/chroma_agent/action_plugins/manage_targets.py
@@ -458,6 +458,8 @@ def _resource_xml(label, ra, nvpair={}, ops={}):
 
     attr = ET.SubElement(res, "operations")
     for key in ["start", "stop", "monitor"]:
+        if key not in ops:
+            ops[key] = {}
         action = agent.find('.//action[@name="{}"]'.format(key))
         if "interval" not in ops[key]:
             ops[key]["interval"] = action.get("interval", "0s")

--- a/chroma_agent/device_plugins/corosync.py
+++ b/chroma_agent/device_plugins/corosync.py
@@ -111,6 +111,8 @@ class CorosyncPlugin(DevicePlugin):
             # ENOENT is fine here.  Pacemaker might not be installed yet.
             if e.errno != errno.ENOENT:
                 raise
+            else:
+                return None
 
         if rc not in [0, 10]:  # 10 Corosync is not running on this node
             daemon_log.warning(


### PR DESCRIPTION
This takes most of #58 and then returns none to simulate what was happening with the exception sandbox. This is a temporary workaround to get further in SSI testing.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>