### PR TITLE
Ensure node names are FQDNs when configuring pacemaker

### DIFF
--- a/chroma_agent/action_plugins/agent_updates.py
+++ b/chroma_agent/action_plugins/agent_updates.py
@@ -25,6 +25,7 @@ def configure_repo(filename, file_contents):
     full_filename = os.path.join(REPO_PATH, filename)
     temp_full_filename = full_filename + ".tmp"
 
+    # this format needs to match create_repo() in manager agent-bootstrap-script
     file_contents = file_contents.format(
         crypto.AUTHORITY_FILE, crypto.PRIVATE_KEY_FILE, crypto.CERTIFICATE_FILE
     )

--- a/chroma_agent/action_plugins/manage_corosync2.py
+++ b/chroma_agent/action_plugins/manage_corosync2.py
@@ -7,6 +7,8 @@
 Corosync verification
 """
 
+import socket
+
 from chroma_agent.log import console_log
 from chroma_agent.lib.shell import AgentShell
 from chroma_agent.lib.corosync import CorosyncRingInterface
@@ -44,9 +46,11 @@ def configure_corosync2_stage_1(mcast_port, pcs_password):
         "-c",
         "echo %s | passwd --stdin %s" % (pcs_password, PCS_USER),
     ]
+    set_hostname_command = ["hostnamectl", "set-hostname", socket.getfqdn()]
 
     return agent_ok_or_error(
         AgentShell.run_canned_error_message(set_password_command)
+        or AgentShell.run_canned_error_message(set_hostname_command)
         or firewall_control.add_rule(mcast_port, "udp", "corosync", persist=True)
         or firewall_control.add_rule(PCS_TCP_PORT, "tcp", "pcs", persist=True)
         or pcsd_service.start()


### PR DESCRIPTION
This can happen if corosync ring0 was configured via IP instead of FQDN

Signed-off-by: Nathaniel Clark <nclark@whamcloud.com>