### PR TITLE
Set default for journal PRIORITY field

### DIFF
--- a/chroma_agent/device_plugins/systemd_journal.py
+++ b/chroma_agent/device_plugins/systemd_journal.py
@@ -16,6 +16,7 @@ import datetime
 import pytz
 from tzlocal import get_localzone
 import systemd.journal
+import syslog
 
 # FIXME: shonky scope of this, it should be part of SYslogdeviceplugin and get set up and torn down appropriately
 _queue = Queue.Queue()
@@ -47,7 +48,7 @@ def parse_journal(data):
 
     return {
         "datetime": datetime.datetime.isoformat(utc_dt),
-        "severity": data["PRIORITY"],
+        "severity": data.get("PRIORITY", syslog.LOG_INFO),
         "facility": data.get("SYSLOG_FACILITY", 3),
         "source": data.get("SYSLOG_IDENTIFIER", "unknown"),
         "message": data["MESSAGE"],


### PR DESCRIPTION
In some cases a journal entry can be parsed that is missing the PRIORITY field.
Use syslog LOG_INFO by default.

Fixes whamcloud/integrated-manager-for-lustre#850

Signed-off-by: Nathaniel Clark <nclark@whamcloud.com>