### PR TITLE
Move set_iml_profile

### DIFF
--- a/chroma_agent/action_plugins/settings_management.py
+++ b/chroma_agent/action_plugins/settings_management.py
@@ -18,11 +18,12 @@ def set_profile(profile_json):
 
     try:
         config.set("settings", "profile", profile)
-        set_iml_profile(
-            profile.get("name"), profile.get("bundles"), profile.get("packages")
-        )
     except ConfigKeyExistsError:
         config.update("settings", "profile", profile)
+
+    set_iml_profile(
+        profile.get("name"), profile.get("bundles"), profile.get("packages")
+    )
 
 
 def set_agent_config(key, val):


### PR DESCRIPTION
Always run `set_iml_profile`.

Fixes #84.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>