### PR TITLE
Enable iml-storage-server.target

### DIFF
--- a/50-chroma-agent.preset
+++ b/50-chroma-agent.preset
@@ -1,1 +1,2 @@
+enable iml-storage-server.target
 enable chroma-agent.service


### PR DESCRIPTION
Make sure to enable `iml-storage-server.target` in the
`chroma-agent.preset`.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>