### PR TITLE
iml-storage-server.target preset not called

### DIFF
--- a/python-iml-agent.spec
+++ b/python-iml-agent.spec
@@ -142,7 +142,8 @@ setenforce 0
 
 rm -f /var/lib/iml/zfs_store.json
 
-systemctl preset %{unit_name} >/dev/null 2>&1
+systemctl preset iml-storage-server.target
+systemctl preset %{unit_name}
 
 # this will either convert an old (pre-4.1) config or initialize
 chroma-agent convert_agent_config


### PR DESCRIPTION
Fixes #89.

In https://github.com/whamcloud/iml-agent/blob/0840c911bbe63e493082469782af849d74736a87/python-iml-agent.spec#L145

We call preset on `chroma-agent.service`.

We also need to call it on `iml-storage-server.target`

Signed-off-by: Joe Grund <jgrund@whamcloud.io>