### PR TITLE
Improve infinite loop case in scanner_cmd

### DIFF
--- a/chroma_agent/device_plugins/block_devices.py
+++ b/chroma_agent/device_plugins/block_devices.py
@@ -38,16 +38,22 @@ def scanner_cmd(cmd):
     client.sendall(json.dumps(cmd) + "\n")
 
     out = ""
+    begin = 0
 
     while True:
         out += client.recv(1024)
+        # Messages are expected to be separated by a newline
+        # But sometimes it is not placed in the end of the line
+        # Thus, take out only the first one
+        idx = out.find("\n", begin)
 
-        if out.endswith("\n"):
+        if idx >= 0:
 
             try:
-                return json.loads(out)
+                return json.loads(out[:idx])
             except ValueError:
-                pass
+                return None
+        begin = len(out)
 
 
 def get_default(prop, default_value, x):


### PR DESCRIPTION
This fix came out from the discussion: https://github.com/whamcloud/device-scanner/issues/252
In short, by some means, buffer `out` doesn't seem to end at a newline, which supposed to be a separator between messages. This makes `JSON` in the buffer inconsistent and leads to potentially infinite loop as data is feed from `device-scanner` successfully and constantly.