### PR TITLE
Don't loose job stats for one job on multiple targets.

### DIFF
--- a/chroma_agent/device_plugins/audit/lustre/__init__.py
+++ b/chroma_agent/device_plugins/audit/lustre/__init__.py
@@ -573,11 +573,14 @@ class ObdfilterAudit(TargetAudit):
             stat["read"] = stat.pop("read_bytes")
             stat["write"] = stat.pop("write_bytes")
 
+            # Tagging by job_id and target name so the one job for different targets is not ignored.
+            job_tag = str(target_name) + str(stat["job_id"])
+
             #  Record that we know about this stat
-            latest_job_stat_snapshot_times[stat["job_id"]] = stat["snapshot_time"]
+            latest_job_stat_snapshot_times[job_tag] = stat["snapshot_time"]
 
             #  if we knew about this last run, and the time is new, then report it
-            if self.job_stat_last_snapshot_time[stat["job_id"]] < stat["snapshot_time"]:
+            if self.job_stat_last_snapshot_time[job_tag] < stat["snapshot_time"]:
                 stats_to_return.append(stat)
 
         #  The local dict will have all the current times for jobs we are tracking, so update the instance copy.

--- a/chroma_agent/device_plugins/audit/lustre/__init__.py
+++ b/chroma_agent/device_plugins/audit/lustre/__init__.py
@@ -573,17 +573,15 @@ class ObdfilterAudit(TargetAudit):
             stat["read"] = stat.pop("read_bytes")
             stat["write"] = stat.pop("write_bytes")
 
+            job_id = stat["job_id"]
+            snapshot_time = stat["snapshot_time"]
+
             #  Tagging by target name and job_id so the one job for different targets is not ignored
             #  Record that we know about this stat
-            latest_job_stat_snapshot_times[target_name][stat["job_id"]] = stat[
-                "snapshot_time"
-            ]
+            latest_job_stat_snapshot_times[target_name][job_id] = snapshot_time
 
             #  if we knew about this last run, and the time is new, then report it
-            if (
-                self.job_stat_last_snapshot_time[target_name][stat["job_id"]]
-                < stat["snapshot_time"]
-            ):
+            if self.job_stat_last_snapshot_time[target_name][job_id] < snapshot_time:
                 stats_to_return.append(stat)
 
         #  The local dict will have all the current times for jobs we are tracking, so update the instance copy.

--- a/tests/audit/test_obdfilter_audit.py
+++ b/tests/audit/test_obdfilter_audit.py
@@ -81,7 +81,7 @@ class TestObdfilterAuditReadingJobStats(unittest.TestCase):
         res = self.audit.get_job_stats("OST0000")
         self.assertEqual(
             self.audit.job_stat_last_snapshot_time,
-            {"OST000016": 1416616379},
+            {"OST0000": {16: 1416616379}},
             self.audit.job_stat_last_snapshot_time,
         )
         self.assertEqual(len(res), 1, res)
@@ -91,7 +91,7 @@ class TestObdfilterAuditReadingJobStats(unittest.TestCase):
         self.assertEqual(res, [], res)
         self.assertEqual(
             self.audit.job_stat_last_snapshot_time,
-            {"OST000016": 1416616379},
+            {"OST0000": {16: 1416616379}},
             self.audit.job_stat_last_snapshot_time,
         )
 
@@ -120,13 +120,13 @@ class TestObdfilterAuditReadingJobStats(unittest.TestCase):
         #  Test that only one record is in the cache, the latest record, and that this new record is returned
         res = self.audit.get_job_stats("OST0000")
         self.assertTrue(
-            {"OST000016": 1416616379}
+            {"OST0000": {16: 1416616379}}
             not in self.audit.job_stat_last_snapshot_time.items(),
             self.audit.job_stat_last_snapshot_time,
         )
         self.assertEqual(
             self.audit.job_stat_last_snapshot_time,
-            {"OST000016": 1416616599},
+            {"OST0000": {16: 1416616599}},
             self.audit.job_stat_last_snapshot_time,
         )
         self.assertEqual(len(res), 1, res)
@@ -186,7 +186,7 @@ class TestObdfilterAuditReadingJobStats(unittest.TestCase):
         res = self.audit.get_job_stats("OST0000")
         self.assertEqual(
             self.audit.job_stat_last_snapshot_time,
-            {"OST000017": 1416616399},
+            {"OST0000": {17: 1416616399}},
             self.audit.job_stat_last_snapshot_time,
         )
         self.assertEqual(len(res), 1, res)

--- a/tests/audit/test_obdfilter_audit.py
+++ b/tests/audit/test_obdfilter_audit.py
@@ -81,7 +81,7 @@ class TestObdfilterAuditReadingJobStats(unittest.TestCase):
         res = self.audit.get_job_stats("OST0000")
         self.assertEqual(
             self.audit.job_stat_last_snapshot_time,
-            {16: 1416616379},
+            {"OST000016": 1416616379},
             self.audit.job_stat_last_snapshot_time,
         )
         self.assertEqual(len(res), 1, res)
@@ -91,7 +91,7 @@ class TestObdfilterAuditReadingJobStats(unittest.TestCase):
         self.assertEqual(res, [], res)
         self.assertEqual(
             self.audit.job_stat_last_snapshot_time,
-            {16: 1416616379},
+            {"OST000016": 1416616379},
             self.audit.job_stat_last_snapshot_time,
         )
 
@@ -120,12 +120,13 @@ class TestObdfilterAuditReadingJobStats(unittest.TestCase):
         #  Test that only one record is in the cache, the latest record, and that this new record is returned
         res = self.audit.get_job_stats("OST0000")
         self.assertTrue(
-            {16: 1416616379} not in self.audit.job_stat_last_snapshot_time.items(),
+            {"OST000016": 1416616379}
+            not in self.audit.job_stat_last_snapshot_time.items(),
             self.audit.job_stat_last_snapshot_time,
         )
         self.assertEqual(
             self.audit.job_stat_last_snapshot_time,
-            {16: 1416616599},
+            {"OST000016": 1416616599},
             self.audit.job_stat_last_snapshot_time,
         )
         self.assertEqual(len(res), 1, res)
@@ -185,7 +186,7 @@ class TestObdfilterAuditReadingJobStats(unittest.TestCase):
         res = self.audit.get_job_stats("OST0000")
         self.assertEqual(
             self.audit.job_stat_last_snapshot_time,
-            {17: 1416616399},
+            {"OST000017": 1416616399},
             self.audit.job_stat_last_snapshot_time,
         )
         self.assertEqual(len(res), 1, res)


### PR DESCRIPTION
When one job is reading/writing on multiple targets the job statistics
are lost for some targets, if timestamps do not differ.

When using `target_name + job_id` binding as a key for job's snapshot
time, it becomes more common for target and don't eat much memory
though.