### PR TITLE
Create Mount Only When Necessary

### DIFF
--- a/chroma_agent/action_plugins/manage_client_mounts.py
+++ b/chroma_agent/action_plugins/manage_client_mounts.py
@@ -6,8 +6,6 @@
 import os
 import errno
 
-from toolz.functoolz import pipe, partial
-
 from chroma_agent.lib.shell import AgentShell
 from chroma_agent.device_plugins.block_devices import get_local_mounts
 

--- a/chroma_agent/action_plugins/manage_client_mounts.py
+++ b/chroma_agent/action_plugins/manage_client_mounts.py
@@ -40,15 +40,21 @@ def create_fstab_entry(mountspec, mountpoint):
         f.write(FSTAB_ENTRY_TEMPLATE % (mountspec, mountpoint))
 
 
-def mount_lustre_filesystem(mountspec, mountpoint):
-    try:
-        os.makedirs(mountpoint, 0o755)
-    except OSError as e:
-        if e.errno != errno.EEXIST:
-            raise
+def lustre_filesystem_mount_exists(mountpoint):
+    out = AgentShell.try_run(["cat", "/proc/mounts"])
+    return mountpoint in out
 
-    create_fstab_entry(mountspec, mountpoint)
-    AgentShell.try_run(["/bin/mount", mountpoint])
+
+def mount_lustre_filesystem(mountspec, mountpoint):
+    if not (lustre_filesystem_mount_exists(mountpoint)):
+        try:
+            os.makedirs(mountpoint, 0o755)
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+                raise
+
+        create_fstab_entry(mountspec, mountpoint)
+        AgentShell.try_run(["/bin/mount", mountpoint])
 
 
 def mount_lustre_filesystems(filesystems):

--- a/chroma_agent/action_plugins/manage_client_mounts.py
+++ b/chroma_agent/action_plugins/manage_client_mounts.py
@@ -51,15 +51,17 @@ def lustre_filesystem_mount_exists(mountpoint):
 
 
 def mount_lustre_filesystem(mountspec, mountpoint):
-    if not (lustre_filesystem_mount_exists(mountpoint)):
-        try:
-            os.makedirs(mountpoint, 0o755)
-        except OSError as e:
-            if e.errno != errno.EEXIST:
-                raise
+    if lustre_filesystem_mount_exists(mountpoint):
+        return
 
-        create_fstab_entry(mountspec, mountpoint)
-        AgentShell.try_run(["/bin/mount", mountpoint])
+    try:
+        os.makedirs(mountpoint, 0o755)
+    except OSError as e:
+        if e.errno != errno.EEXIST:
+            raise
+
+    create_fstab_entry(mountspec, mountpoint)
+    AgentShell.try_run(["/bin/mount", mountpoint])
 
 
 def mount_lustre_filesystems(filesystems):

--- a/chroma_agent/action_plugins/manage_client_mounts.py
+++ b/chroma_agent/action_plugins/manage_client_mounts.py
@@ -44,14 +44,12 @@ def create_fstab_entry(mountspec, mountpoint):
 
 
 def lustre_filesystem_mount_exists(mountpoint):
-    out = get_local_mounts()
-
-    def mountpoint_matches(mountpoint, item):
-        return mountpoint in item
-
-    mountpoint_matches_item = partial(mountpoint_matches, mountpoint)
-
-    return pipe(out, partial(filter, partial(filter, mountpoint_matches_item)))
+    return next(
+        iter(
+            [m for m in get_local_mounts() if m[2] == "lustre" and m[1] == mountpoint]
+        ),
+        None,
+    )
 
 
 def mount_lustre_filesystem(mountspec, mountpoint):

--- a/tests/actions_plugins/test_manage_client_mounts.py
+++ b/tests/actions_plugins/test_manage_client_mounts.py
@@ -18,7 +18,6 @@ class TestClientMountManagement(CommandCaptureTestCase):
     @patch("chroma_agent.action_plugins.manage_client_mounts.delete_fstab_entry")
     @patch("chroma_agent.action_plugins.manage_client_mounts.create_fstab_entry")
     def test_mount_lustre_filesystem(self, create, delete):
-        self.add_command(("cat", "/proc/mounts"))
         self.add_command(("/bin/mount", "/mnt/lustre_clients/foobar"))
 
         from chroma_agent.action_plugins.manage_client_mounts import (

--- a/tests/actions_plugins/test_manage_client_mounts.py
+++ b/tests/actions_plugins/test_manage_client_mounts.py
@@ -18,6 +18,7 @@ class TestClientMountManagement(CommandCaptureTestCase):
     @patch("chroma_agent.action_plugins.manage_client_mounts.delete_fstab_entry")
     @patch("chroma_agent.action_plugins.manage_client_mounts.create_fstab_entry")
     def test_mount_lustre_filesystem(self, create, delete):
+        self.add_command(("cat", "/proc/mounts"))
         self.add_command(("/bin/mount", "/mnt/lustre_clients/foobar"))
 
         from chroma_agent.action_plugins.manage_client_mounts import (


### PR DESCRIPTION
The database does not currently reflect the actual state of mounts, so if it says the state is mounted, it could
actually be unmounted. The device scanner will eventually resolve this issue, but until then, we should check to see if
a mount exists before creating the mount. This will allow us to attempt to create a mount, even if the mount already
exists (in which case it would be a noop). This is useful when attempting to stream stratagem results to the client. We
can ensure that the client is mounted before attempting to stream.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>