### PR TITLE
Ensure chronyd is stopped and disabled within manage_ntp plugin

### DIFF
--- a/chroma_agent/action_plugins/manage_ntp.py
+++ b/chroma_agent/action_plugins/manage_ntp.py
@@ -9,6 +9,7 @@ from iml_common.lib.service_control import ServiceControl
 
 
 ntp_service = ServiceControl.create("ntpd")
+chrony_service = ServiceControl.create("chronyd")
 
 
 def unconfigure_ntp():
@@ -30,6 +31,9 @@ def configure_ntp(ntp_server):
     if error:
         return error
     else:
+        chrony_service.stop(validate_time=0.5)
+        chrony_service.disable()
+        ntp_service.enable()
         return agent_ok_or_error(ntp_service.restart())
 
 


### PR DESCRIPTION
with the advent of `chronyd`, `ntpd`, which IML currently relies on may
be inactive.

Make sure we stop and disable chronyd within the manage_ntp agent
plugin.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>