### PR TITLE
Fix kernel_status call to check required_kernel for modules

### DIFF
--- a/chroma_agent/action_plugins/agent_updates.py
+++ b/chroma_agent/action_plugins/agent_updates.py
@@ -6,6 +6,7 @@ import subprocess
 import re
 import os
 import errno
+from distutils.version import LooseVersion
 
 from chroma_agent.lib.shell import AgentShell
 from chroma_agent.device_plugins.action_runner import CallbackAfterResponse
@@ -166,49 +167,92 @@ def _check_HYD4050():
     return None
 
 
+def kver_gt(kver1, kver2, arch):
+    """
+    True if kern1 is greater than kern2
+    kern is of the form: "kernel-3.10.0-1062.el7.x86_64" (`rpm -q kernel`)
+    """
+
+    def kver_split(kver, arch):
+        if not kver:
+            return "0", "0"
+        v, r = (kver.split("-", 2) + ["0", "0"])[1:3]
+        ra = r.split(".")
+        if ra[-1] == arch:
+            ra.pop()
+        if ra[-1].startswith("el"):
+            ra.pop()
+        return v, ".".join(ra)
+
+    kv1, kr1 = kver_split(kver1, arch)
+    kv2, kr2 = kver_split(kver2, arch)
+    return LooseVersion(kv1) > LooseVersion(kv2) or LooseVersion(kr1) > LooseVersion(
+        kr2
+    )
+
+
+def kernel_ok(kernel, modlist):
+    okay = True
+    kver = kernel.split("-", 1)[1]
+    return AgentShell.run(["modinfo", "-n", "-k", kver] + modlist).rc == 0
+
+
 def kernel_status():
     """
     :return: {'running': {'kernel-X.Y.Z'}, 'required': <'kernel-A.B.C' or None>}
     """
     running_kernel = "kernel-%s" % AgentShell.try_run(["uname", "-r"]).strip()
 
-    if AgentShell.run(["rpm", "-q", "--whatprovides", "kmod-lustre"]).rc == 0:
-        # on a server, a required kernel is a lustre patched kernel since we
-        # are building storage servers that can support both ldiskfs and zfs
-        try:
-            required_kernel = next(
-                k
-                for k in sorted(
-                    AgentShell.try_run(["rpm", "-q", "kernel"]).split("\n"),
-                    reverse=True,
-                )
-                if "_lustre" in k
-            )
-        except (AgentShell.CommandExecutionError, StopIteration):
-            required_kernel = None
-    elif AgentShell.run(["rpm", "-q", "kmod-lustre-client"]).rc == 0:
-        # but on a worker, we can ask kmod-lustre-client what the required
-        # kernel is
-        try:
-            required_kernel_prefix = next(
-                k
-                for k in AgentShell.try_run(
-                    ["rpm", "-q", "--requires", "kmod-lustre-client"]
-                ).split("\n")
-                if "kernel >=" in k
-            ).split(" >= ")[1]
-            required_kernel = AgentShell.try_run(
-                ["rpm", "-q", "kernel-%s*" % required_kernel_prefix]
-            ).split("\n")[0]
-        except (AgentShell.CommandExecutionError, StopIteration):
-            required_kernel = None
-    else:
-        required_kernel = None
-
     available_kernels = []
     for installed_kernel in AgentShell.try_run(["rpm", "-q", "kernel"]).split("\n"):
         if installed_kernel:
             available_kernels.append(installed_kernel)
+
+    arch = AgentShell.try_run(["uname", "-m"]).strip()
+
+    if AgentShell.run(["rpm", "-q", "--whatprovides", "kmod-lustre"]).rc == 0:
+        try:
+            modlist = [
+                os.path.splitext(os.path.basename(k))[0]
+                for k in AgentShell.try_run(
+                    ["rpm", "-ql", "--whatprovides", "lustre-osd", "kmod-lustre"]
+                ).split("\n")
+                if k.endswith(".ko")
+            ]
+
+            required_kernel = None
+            for kernel in available_kernels:
+                if not kver_gt(kernel, required_kernel, arch):
+                    continue
+                if kernel_ok(kernel, modlist):
+                    required_kernel = kernel
+
+        except (AgentShell.CommandExecutionError, StopIteration):
+            required_kernel = None
+
+    elif AgentShell.run(["rpm", "-q", "kmod-lustre-client"]).rc == 0:
+        # but on a worker, we can ask kmod-lustre-client what the required
+        # kernel is
+        try:
+            modlist = [
+                os.path.splitext(os.path.basename(k))[0]
+                for k in AgentShell.try_run(
+                    ["rpm", "-ql", "--whatprovides", "kmod-lustre-client"]
+                ).split("\n")
+                if k.endswith(".ko")
+            ]
+
+            required_kernel = None
+            for kernel in available_kernels:
+                if not kver_gt(kernel, required_kernel, arch):
+                    continue
+                if kernel_ok(kernel, modlist):
+                    required_kernel = kernel
+
+        except (AgentShell.CommandExecutionError, StopIteration):
+            required_kernel = None
+    else:
+        required_kernel = None
 
     return {
         "running": running_kernel,

--- a/chroma_agent/plugin_manager.py
+++ b/chroma_agent/plugin_manager.py
@@ -96,8 +96,8 @@ class DevicePlugin(object):
     """
 
     FAILSAFEDUPDATE = (
-        60
-    )  # We always send an update every 60 cycles (60*10)seconds - 10 minutes.
+        60  # We always send an update every 60 cycles (60*10)seconds - 10 minutes.
+    )
 
     def __init__(self, session):
         self._session = session

--- a/tests/actions_plugins/test_agent_updates.py
+++ b/tests/actions_plugins/test_agent_updates.py
@@ -81,17 +81,49 @@ sslclientcert = {2}
     def test_kernel_status(self):
         def run(arg_list):
             values = {
+                ("rpm", "-q", "kernel"): {
+                    "rc": 0,
+                    "stdout": "kernel-2.6.32-358.2.1.el6.x86_64\n"
+                    "kernel-2.6.32-358.18.1.el6_lustre.x86_64\n",
+                },
+                ("rpm", "-q", "--whatprovides", "kmod-lustre"): {
+                    "rc": 0,
+                    "stdout": "kmod-lustre-1.2.3-1.el6.x86_64\n",
+                },
+                ("rpm", "-ql", "--whatprovides", "lustre-osd", "kmod-lustre"): {
+                    "rc": 0,
+                    "stdout": "/lib/modules/2.6.32-358.18.1.el7_lustre.x86_64/extra/lustre/fs/lustre.ko\n"
+                    "/lib/modules/2.6.32-358.18.1.el7_lustre.x86_64/extra/lustre-osd-ldiskfs/fs/osd_ldiskfs.ko\n",
+                },
                 (
-                    "rpm",
-                    "-q",
-                    "--whatprovides",
-                    "kmod-lustre",
-                ): "kmod-lustre-1.2.3-1.el6.x86_64\n",
-                ("uname", "-r"): "2.6.32-358.2.1.el6.x86_64\n",
-                ("rpm", "-q", "kernel"): "kernel-2.6.32-358.2.1.el6.x86_64\n"
-                "kernel-2.6.32-358.18.1.el6_lustre.x86_64\n",
+                    "modinfo",
+                    "-n",
+                    "-k",
+                    "2.6.32-358.2.1.el6.x86_64",
+                    "lustre",
+                    "osd_ldiskfs",
+                ): {"rc": 1, "stdout": ""},
+                (
+                    "modinfo",
+                    "-n",
+                    "-k",
+                    "2.6.32-358.18.1.el6_lustre.x86_64",
+                    "lustre",
+                    "osd_ldiskfs",
+                ): {
+                    "rc": 0,
+                    "stdout": "/lib/modules/2.6.32-358.18.1.el7_lustre.x86_64/extra/lustre/fs/lustre.ko\n"
+                    "/lib/modules/2.6.32-358.18.1.el7_lustre.x86_64/extra/lustre-osd-ldiskfs/fs/osd_ldiskfs.ko\n",
+                },
+                ("uname", "-m"): {"rc": 0, "stdout": "x86_64\n"},
+                ("uname", "-r"): {"rc": 0, "stdout": "2.6.32-358.2.1.el6.x86_64\n"},
             }
-            return Shell.RunResult(0, values[tuple(arg_list)], "", False)
+            return Shell.RunResult(
+                values[tuple(arg_list)]["rc"],
+                values[tuple(arg_list)]["stdout"],
+                "",
+                False,
+            )
 
         with patch("chroma_agent.lib.shell.AgentShell.run", side_effect=run):
             result = agent_updates.kernel_status()


### PR DESCRIPTION
Find latest kernel that supports all lustre modules installed via rpm.

Fixes Issue whamcloud/integrated-manager-for-lustre#1287 

Signed-off-by: Nathaniel Clark <nclark@whamcloud.com>