### PR TITLE
Handle single node resources when finding resource constraint

### DIFF
--- a/chroma_agent/action_plugins/manage_targets.py
+++ b/chroma_agent/action_plugins/manage_targets.py
@@ -863,11 +863,17 @@ def _find_resource_constraint(ha_label, primary):
     if result.rc != 0:
         return None
 
+    et = ET.fromstring(result.stdout)
+
+    # Handle single location case.
+    if et.tag == "rsc_location":
+        return et.get("node")
+
     def _byscore(elem):
         return int(elem.get("score"))
 
     # Higher score is primary, lower score is secondary
-    locations = ET.fromstring(result.stdout).findall("rsc_location")
+    locations = et.findall("rsc_location")
 
     if locations:
         if primary:


### PR DESCRIPTION
In the case of a resource configured on a single node, the result of
`cibxpath("query", '//constraints/rsc_location[@rsc="{}"]'.format(ha_label))` will be a single node
instead of a top-level node containing child nodes.

In this case, we should check the single node directly and fallback to
fetching children if the top-level node is not `rsc_location`.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>