### PR TITLE
Check resource location constraint with trailing label

### DIFF
--- a/chroma_agent/action_plugins/manage_targets.py
+++ b/chroma_agent/action_plugins/manage_targets.py
@@ -591,7 +591,7 @@ def configure_target_ha(
         if result.rc != 0:
             return agent_error("Failed to create {}: {}".format(ha_label, result.rc))
 
-    elif _find_resource_constraint(ha_label, primary):
+    elif _find_resource_constraint(_constraint(ha_label, primary), primary):
         # Secondary server already had resource constraint - assume configure only
         return agent_result_ok
 


### PR DESCRIPTION
When we check for a constraint on a secondary target, make sure we add
the label in so we don't match primary targets.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>