### PR TITLE
Avoid yielding None in get_param_lines

### DIFF
--- a/chroma_agent/device_plugins/audit/mixins.py
+++ b/chroma_agent/device_plugins/audit/mixins.py
@@ -27,16 +27,13 @@ class LustreGetParamMixin(object):
         """
         stdout = self._get_param("-n", path).strip()
 
-        if not stdout:
-            yield None
-            return
-
-        for line in stdout.split("\n"):
-            if filter_f:
-                if filter_f(line):
+        if stdout:
+            for line in stdout.split("\n"):
+                if filter_f:
+                    if filter_f(line):
+                        yield line
+                else:
                     yield line
-            else:
-                yield line
 
     def get_param_raw(self, path):
         return self._get_param("-n", path)


### PR DESCRIPTION
In `get_param_lines` if stdout is empty, we end up yielding `None`.

The `None` gets yielded to any consumers trying to iterate this generator,
and does not seem like what was intended.

Instead or returning early, gate line yielding on stdout having content.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>