### PR TITLE
Filter unclean nodes from crm output

### DIFF
--- a/chroma_agent/action_plugins/manage_corosync2.py
+++ b/chroma_agent/action_plugins/manage_corosync2.py
@@ -178,27 +178,6 @@ def _nodes_in_cluster():
     return nodes
 
 
-def change_mcast_port(old_mcast_port, new_mcast_port):
-    """
-    Update corosync configuration with a new mcast_port on this managed server (not all the nodes in the cluster)
-    Corosync will read the updated value in the configuration file, which it is polling for updates.
-
-    Return: Value using simple return protocol
-    """
-    file_edit_args = [
-        "sed",
-        "-i.bak",
-        "s/mcastport:.*/mcastport: %s/g" % new_mcast_port,
-        COROSYNC_CONF_PATH,
-    ]
-
-    return agent_ok_or_error(
-        firewall_control.remove_rule(old_mcast_port, "udp", "corosync", persist=True)
-        or firewall_control.add_rule(new_mcast_port, "udp", "corosync", persist=True)
-        or AgentShell.run_canned_error_message(file_edit_args)
-    )
-
-
 def unconfigure_corosync2(host_fqdn, mcast_port):
     """
     Unconfigure the corosync application.
@@ -241,6 +220,5 @@ ACTIONS = [
     stop_corosync2,
     configure_corosync2_stage_1,
     configure_corosync2_stage_2,
-    change_mcast_port,
     unconfigure_corosync2,
 ]

--- a/chroma_agent/action_plugins/manage_targets.py
+++ b/chroma_agent/action_plugins/manage_targets.py
@@ -57,7 +57,7 @@ def _get_resource_locations(xml):
 
     nodes = filter_unclean_nodes(dom.findall("nodes/node"))
 
-    if nodes is None or nodes == []:
+    if nodes == []:
         return locations
 
     for res in dom.findall(".//resource"):

--- a/chroma_agent/device_plugins/corosync.py
+++ b/chroma_agent/device_plugins/corosync.py
@@ -68,7 +68,7 @@ class CorosyncPlugin(DevicePlugin):
 
             nodes = filter_unclean_nodes(root.findall("nodes/node"))
 
-            if nodes is None:
+            if nodes == []:
                 return None
 
             return_dict["nodes"] = dict(

--- a/chroma_agent/lib/corosync.py
+++ b/chroma_agent/lib/corosync.py
@@ -35,16 +35,9 @@ operstate = "/sys/class/net/{}/operstate"
 
 def filter_unclean_nodes(nodes):
     """ Given a list of nodes,
-    returns either the clean nodes, or None if the local node is unclean.
+    returns the clean ones.
     """
     x = groupby(lambda x: x.get("unclean"), nodes)
-
-    local_node = get_cluster_node_name()
-
-    unclean_local = any(True for y in x.get("true", []) if y.get("name") == local_node)
-
-    if unclean_local:
-        return None
 
     return x.get("false", [])
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Django==1.6.11
 iml-common>=1.4,<1.5
 lockfile==0.9.1
 mock==1.0.1
-nose==1.2.1
+nose
 requests==2.6.0
 tablib==0.9.11
 toolz

--- a/tests/device_plugins/test_corosync.py
+++ b/tests/device_plugins/test_corosync.py
@@ -77,7 +77,6 @@ class TestCorosync(CommandCaptureTestCase):
 
         self.add_commands(
             CommandCaptureCommand(CMD, stdout=crm_one_shot_xml),
-            CommandCaptureCommand(("crm_node", "-n"), rc=0, stdout="storage0.node"),
             CommandCaptureCommand(("systemctl", "is-active", "corosync"), rc=0),
             CommandCaptureCommand(("systemctl", "is-active", "pacemaker"), rc=0),
         )

--- a/tests/device_plugins/test_corosync.py
+++ b/tests/device_plugins/test_corosync.py
@@ -77,6 +77,7 @@ class TestCorosync(CommandCaptureTestCase):
 
         self.add_commands(
             CommandCaptureCommand(CMD, stdout=crm_one_shot_xml),
+            CommandCaptureCommand(("crm_node", "-n"), rc=0, stdout="storage0.node"),
             CommandCaptureCommand(("systemctl", "is-active", "corosync"), rc=0),
             CommandCaptureCommand(("systemctl", "is-active", "pacemaker"), rc=0),
         )

--- a/tests/test_corosync_config.py
+++ b/tests/test_corosync_config.py
@@ -278,7 +278,6 @@ class TestConfigureCorosync(CommandCaptureTestCase):
         from chroma_agent.action_plugins.manage_corosync2 import (
             configure_corosync2_stage_2,
         )
-        from chroma_agent.action_plugins.manage_corosync2 import change_mcast_port
         from chroma_agent.action_plugins.manage_corosync2 import PCS_TCP_PORT
         from chroma_agent.action_plugins.manage_corosync_common import configure_network
 
@@ -403,30 +402,6 @@ class TestConfigureCorosync(CommandCaptureTestCase):
         self.mock_remove_port.reset_mock()
         self.mock_add_port.reset_mock()
         self.mock_corosync_service.reset_mock()
-
-        # ...now change corosync mcast port
-        old_mcast_port = "4242"
-        new_mcast_port = "4246"
-
-        # add shell command to be expected when updating corosync.conf file with new mcast port value
-        self.add_command(
-            (
-                "sed",
-                "-i.bak",
-                "s/mcastport:.*/mcastport: %s/g" % new_mcast_port,
-                "/etc/corosync/corosync.conf",
-            )
-        )
-
-        self.assertEqual(
-            agent_result_ok, change_mcast_port(old_mcast_port, new_mcast_port)
-        )
-
-        # check correct firewall and service calls were made
-        self.mock_add_port.assert_has_calls([mock.call(new_mcast_port, "udp")])
-        self.mock_remove_port.assert_has_calls([mock.call(old_mcast_port, "udp")])
-        with self.assertRaises(AssertionError):
-            self.mock_corosync_service.enable.assert_any_call()
 
         self.assertRanAllCommandsInOrder()
 


### PR DESCRIPTION
If a node is unclean, don't report it in agent output.

Open question is whether we should not send the entire report if a node
is unclean.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>