### PR TITLE
Return empty set if get_param fails in list_params()

### DIFF
--- a/chroma_agent/device_plugins/audit/mixins.py
+++ b/chroma_agent/device_plugins/audit/mixins.py
@@ -56,7 +56,12 @@ class LustreGetParamMixin(object):
         return ".".join(arr)
 
     def list_params(self, path):
-        return self._get_param("-N", path).strip().split("\n")
+        """ Return list of parameters found in path.  Or [] if none, or get_param fails.
+        """
+        try:
+            return self._get_param("-N", path).strip().split("\n")
+        except AgentShell.CommandExecutionError:
+            return []
 
 
 class FileSystemMixin(object):


### PR DESCRIPTION
Fixes whamcloud/integrated-manager-for-lustre#1536

Signed-off-by: Nathaniel Clark <nclark@whamcloud.com>