### PR TITLE
Allow Failover/back to act as move if no constraints

### DIFF
--- a/chroma_agent/action_plugins/manage_targets.py
+++ b/chroma_agent/action_plugins/manage_targets.py
@@ -843,11 +843,11 @@ def _failoverback_target(ha_label, primary):
     """
     node = _find_resource_constraint(ha_label, primary)
     if not node:
-        return agent_error(
-            "Unable to find the {} server for '{}'".format(
-                "primary" if primary else "secondary", ha_label
-            )
+        console_log.info(
+            "failoverback: Host move to %s requested, no constraints, so moving here",
+            "primary" if primary else "secondary",
         )
+        node = get_cluster_node_name()
 
     error = _move_target(ha_label, node)
 


### PR DESCRIPTION
When a pacemaker config lacks location scores, allow failover and
failback to act as a "move here" command.

Issue whamcloud/integrated-manager-for-lustre#1498

Signed-off-by: Nathaniel Clark <nclark@whamcloud.com>