### PR TITLE
Add optional overrides file to services

### DIFF
--- a/chroma-agent.service
+++ b/chroma-agent.service
@@ -8,6 +8,7 @@ PartOf=iml-storage-server.target
 Type=simple
 ExecStart=/usr/bin/chroma-agent-daemon
 EnvironmentFile=/etc/iml/manager-url.conf
+EnvironmentFile=-/etc/iml/overrides.conf
 Restart=on-failure
 StandardOutput=journal
 StandardError=journal


### PR DESCRIPTION
Adding an optional overrides file to the services will allow us to
override service environment variables easily.

Signed-off-by: johnsonw <wjohnson@whamcloud.com>