### PR TITLE
Use systemd_post instead of systemctl preset

### DIFF
--- a/python-iml-agent.spec
+++ b/python-iml-agent.spec
@@ -137,8 +137,8 @@ setenforce 0
 
 rm -f /var/lib/iml/zfs_store.json
 
-systemctl preset iml-storage-server.target
-systemctl preset %{unit_name}
+%systemd_post iml-storage-server.target
+%systemd_post %{unit_name}
 
 # this will either convert an old (pre-4.1) config or initialize
 chroma-agent convert_agent_config


### PR DESCRIPTION
Use `%systemd_post` when installing the agent. This will prevent presets
from being reevaluated each time we update.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>
